### PR TITLE
Fix namespace issue with nth-of-type

### DIFF
--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.1
+
+- **FIX**: Fix namespace check for `:nth-of-type`.
+
 ## 0.5.0
 
 - **NEW**: Deprecate `commentsiter` and `selectiter` in favor of `icomments` and `iselect`. Expect removal in version 1.0.

--- a/soupsieve/__meta__.py
+++ b/soupsieve/__meta__.py
@@ -186,5 +186,5 @@ def parse_version(ver, pre=False):
     return Version(major, minor, micro, release, pre, post, dev)
 
 
-__version_info__ = Version(0, 5, 0, "final")
+__version_info__ = Version(0, 5, 1, "final")
 __version__ = __version_info__._get_canonical()

--- a/soupsieve/css_match.py
+++ b/soupsieve/css_match.py
@@ -282,7 +282,7 @@ class CSSMatch:
 
         return(
             (child.name == (util.lower(el.name) if not self.is_xml() else el.name)) and
-            (self.supports_namespaces() and self.get_namespace(child) == self.get_namespace(el))
+            (not self.supports_namespaces() or self.get_namespace(child) == self.get_namespace(el))
         )
 
     def match_nth(self, el, nth):

--- a/tests/test_bs4_cases.py
+++ b/tests/test_bs4_cases.py
@@ -1,0 +1,90 @@
+"""Test that we don't fail the same test cases that Beautiful Soup fails for."""
+from bs4 import BeautifulSoup
+import unittest
+import soupsieve as sv
+
+
+class SelectorNthOfTypeBugTest(unittest.TestCase):
+    """
+    Original Beautiful soup test html document.
+
+    http://bazaar.launchpad.net/~leonardr/beautifulsoup/bs4/view/head:/bs4/tests/test_tree.py, line 1627.
+    """
+
+    HTML = """
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN"
+"http://www.w3.org/TR/html4/strict.dtd">
+<html>
+<head>
+<title>The title</title>
+<link rel="stylesheet" href="blah.css" type="text/css" id="l1">
+</head>
+<body>
+<custom-dashed-tag class="dashed" id="dash1">Hello there.</custom-dashed-tag>
+<div id="main" class="fancy">
+<div id="inner">
+<h1 id="header1">An H1</h1>
+<p>Some text</p>
+<p class="onep" id="p1">Some more text</p>
+<h2 id="header2">An H2</h2>
+<p class="class1 class2 class3" id="pmulti">Another</p>
+<a href="http://bob.example.org/" rel="friend met" id="bob">Bob</a>
+<h2 id="header3">Another H2</h2>
+<a id="me" href="http://simonwillison.net/" rel="me">me</a>
+<span class="s1">
+<a href="#" id="s1a1">span1a1</a>
+<a href="#" id="s1a2">span1a2 <span id="s1a2s1">test</span></a>
+<span class="span2">
+<a href="#" id="s2a1">span2a1</a>
+</span>
+<span class="span3"></span>
+<custom-dashed-tag class="dashed" id="dash2"/>
+<div data-tag="dashedvalue" id="data1"/>
+</span>
+</div>
+<x id="xid">
+<z id="zida"/>
+<z id="zidab"/>
+<z id="zidac"/>
+</x>
+<y id="yid">
+<z id="zidb"/>
+</y>
+<p lang="en" id="lang-en">English</p>
+<p lang="en-gb" id="lang-en-gb">English UK</p>
+<p lang="en-us" id="lang-en-us">English US</p>
+<p lang="fr" id="lang-fr">French</p>
+</div>
+
+<div id="footer">
+</div>
+"""
+
+    def setUp(self):
+        """Setup."""
+
+        self.soup = BeautifulSoup(self.HTML, 'html.parser')
+
+    def test_parent_nth_of_type_preconditions(self):
+        """Test `nth` type preconditions."""
+
+        els = sv.select('div > h1', self.soup, mode=sv.HTML)
+        # check that there is a unique selection
+        self.assertEqual(len(els), 1)
+        self.assertEqual(els[0].string, 'An H1')
+
+        # Show that the `h1`'s parent `div#inner` is the first child of type `div` of the grandparent `div#main`.
+        # so that the selector `div:nth-of-type(1) > h1` should also give `h1`.
+        h1 = els[0]
+        div_inner = h1.parent
+        div_main = div_inner.parent
+        div_main_children = [child for child in div_main.children]
+        self.assertEquals(div_main_children[0], '\n')
+        self.assertEquals(div_main_children[1], div_inner)
+
+    def test_parent_nth_of_type(self):
+        """Test parent of `nth` of type."""
+
+        els = sv.select('div:nth-of-type(1) > h1', self.soup, mode=sv.HTML)
+        self.assertEqual(len(els), 1)
+        self.assertEqual(els[0].string, 'An H1')


### PR DESCRIPTION
In document formats that don't support namespaces, we should not fail the type if namespace doesn't match.