### PR TITLE
Refactor

### DIFF
--- a/docs/src/dictionary/en-custom.txt
+++ b/docs/src/dictionary/en-custom.txt
@@ -39,5 +39,6 @@ substring
 tuple
 tuples
 un
+unpickle
 whitespace
 wordlist

--- a/docs/src/dictionary/en-custom.txt
+++ b/docs/src/dictionary/en-custom.txt
@@ -36,6 +36,7 @@ regex
 sublicense
 substring
 tuple
+tuples
 un
 whitespace
 wordlist

--- a/docs/src/dictionary/en-custom.txt
+++ b/docs/src/dictionary/en-custom.txt
@@ -18,6 +18,7 @@ Virtualenv
 WIP
 XHTML
 accessor
+boolean
 builtin
 deprecations
 html

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -3,6 +3,7 @@
 ## 0.5.3
 
 - **FIX**: Previously, all pseudo classes' selector lists were evaluated as one big group, but now each pseudo classes' selector lists are evaluated separately.
+- **FIX**: CSS selector tokens are not case sensitive.
 
 ## 0.5.2
 

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.3
+
+- **FIX**: Previously all pseudo classes' selector lists were evaluated as one big group, but now each pseudo classes' selector lists are evaluated separately.
+
 ## 0.5.2
 
 - **FIX**: Add missing `s` flag to attribute selector for forced case sensitivity of attribute values.

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -2,7 +2,7 @@
 
 ## 0.5.3
 
-- **FIX**: Previously all pseudo classes' selector lists were evaluated as one big group, but now each pseudo classes' selector lists are evaluated separately.
+- **FIX**: Previously, all pseudo classes' selector lists were evaluated as one big group, but now each pseudo classes' selector lists are evaluated separately.
 
 ## 0.5.2
 

--- a/docs/src/markdown/about/development.md
+++ b/docs/src/markdown/about/development.md
@@ -152,11 +152,11 @@ File            | Description
 
 When a CSS selector string is given to Soup Sieve, it is run through the `CSSParser` class.  `CSSParser` will return a tuple object with one or more `Selector` classes. This tuple is handed to the `SoupSieve` class as a parameter along with things like `namespace` and `mode`. One of the most important things to understand when contributing is the structure of the `Selector` class and the various chained objects.
 
-The `Selector` class is a `namedtuple`. A compiled selector will always return a tuple of these objects. A `Selector` represents one compound selector.  So if you had the selector `div > p`, you would get a tuple with one `Selector`. If you had `div, p`, you would get a tuple with two `Selector`s as this is a selector list of two selectors. With that said, `div > p` will generate a sub-selector that is chained to the top level, but at the top level, there is only one.
+The `Selector` class is a `namedtuple`. A compiled selector will always return a tuple of these objects. A `Selector` represents one compound selector.  So if you had the selector `#!css div > p`, you would get a tuple with one `Selector`. If you had `#!css div, p`, you would get a tuple with two `Selector` objects as this is a selector list of two compound selectors. With that said, `#!css div > p` will generate a sub-selector that is chained to the top level, but at the top level, there is only one.
 
-A compound selector gets parsed into pieces. Each part of a specific compound selector is usually assigned to an attribute in a single `Selector` object, though some attributes can be an tuple of more selectors, as in the case of `*:not(p, div)` where `*` will be one `Selector` with the `:not(p, div)` selector list will be a tuple of containing one tuple of two `Selectors` (one for `p` and one for `div`) under the `selectors` attribute.
+A compound selector gets parsed into pieces. Each part of a specific compound selector is usually assigned to an attribute in a single `Selector` object. The attributes of the `Selector` object may be as simple as a boolean or a string, but hey can also be a tuple of more `Selector` objects. In the case of `#!css *:not(p, div)`, `#!css *` will be one `Selector` and the `#!css :not(p, div)` selector list will be a tuple containing one tuple of two `Selectors` (one for `p` and one for `div`) under the `selectors` attribute.
 
-In short a compound selector is a single `Selector` object that may chain other `Selector` objects. If you provide a selector list, than you will get multiple `Selector`s (one for each compound selector in the list) which in turn may chain other `Selector` objects.
+In short a compound selector is a single `Selector` object that may chain other `Selector` objects depending on the complexity of the compound selector. If you provide a selector list, than you will get multiple `Selector` objects (one for each compound selector in the list) which in turn may chain other `Selector` objects.
 
 ### `Selector`
 
@@ -173,19 +173,19 @@ class Selector(
     """Selector."""
 ```
 
-`Selector`\ Attributes | Description
-------------           | -----------
-`tag`                  | Contains a single [`SelectorTag`](#selectortag) object, or `None`.
-`id`                   | Contains a tuple of ids to match. Usually if multiple conflicting ids are present, it simply won't match a tag, but it allows multiple to handle the syntax `tag#1#2` even if it is invalid.
-`classes`              | Contains a tuple of class names to match.
-`attributes`           | Contains a tuple of attributes. Each attribute is represented as a [`SelectorAttribute`](#selectorattribute).
-`nth`                  | Contains a tuple containing `nth` selectors, each selector being represented as a [`SelectorNth`](#selectornth). `nth` selectors contain things like `:first-child`, `:only-child`, `:nth-child`, `:nth-of-type`, etc.
-`selectors`            | Contains a tuple of tuples of pseudo class selectors: `:is()`, `:not()`, `:has()`, etc. For instance, for a given selector `div:is(.a, .b):not(.c)`, you would have a tuple of tuples: `((Selector(.a), Selector(.b)), (Selector(.c)))`.
-`is_not`               | This is `True` if the current `Selector` is `:not()` pseudo class.
-`is_empty`             | This is `True` if the current selector contained a `:is_empty` pseudo.
-`relation`             | This is will contain a `Selector` object that is a relational match.  For instance, for `div > p + a` would be a `Selector` that contains a `relation` for `p` (another `Selector` object) which also contains a relation of `div`.  When matching, we would match that the tag is `a`, and then check that it's relations match, in this case a direct, previous sibling of `p` which has a direct parent of `div`.
-`rel_type`             | `rel_type` is attached to relational selectors. In the case of `div > p + a`, the relational selectors of `div` and `p` would get a relational type of `>` and `+` respectively.  `:has()` relations are actually stored under the selector attributes instead of `relation`, but they still have `rel_type`s as well. In the case of `p:has(> a)`, the `p` selector would have a `Selector` object in the `selectors` tuple with a `rel_type` of `:>` (has relations are prefixed `:` to denote forward looking relations).
-`is_root`              | This is `True` if the current compound selector contains `:is_root`.
+`Selector`   | Description
+------------ | -----------
+`tag`        | Contains a single [`SelectorTag`](#selectortag) object, or `None`.
+`id`         | Contains a tuple of ids to match. Usually if multiple conflicting ids are present, it simply won't match a tag, but it allows multiple to handle the syntax `tag#1#2` even if it is invalid.
+`classes`    | Contains a tuple of class names to match.
+`attributes` | Contains a tuple of attributes. Each attribute is represented as a [`SelectorAttribute`](#selectorattribute).
+`nth`        | Contains a tuple containing `nth` selectors, each selector being represented as a [`SelectorNth`](#selectornth). `nth` selectors contain things like `:first-child`, `:only-child`, `#!css :nth-child()`, `#!css :nth-of-type()`, etc.
+`selectors`  | Contains a tuple of tuples of pseudo class selectors: `#!css :is()`, `#!css :not()`, `#!css :has()`, etc. For instance, for a given selector `#!css div:is(.a, .b):not(.c)`, you would have a tuple of tuples: `((Selector(.a), Selector(.b)), (Selector(.c)))`.
+`is_not`     | This is `True` if the current `Selector` is `:not()` pseudo class.
+`is_empty`   | This is `True` if the current selector contained a `:is_empty` pseudo.
+`relation`   | This is will contain a `Selector` object that is a relational match.  For instance, for `div > p + a` would be a `Selector` that contains a `relation` for `p` (another `Selector` object) which also contains a relation of `div`.  When matching, we would match that the tag is `a`, and then check that it's relations match, in this case a direct, previous sibling of `p` which has a direct parent of `div`.
+`rel_type`   | `rel_type` is attached to relational selectors. In the case of `#!css div > p + a`, the relational selectors of `div` and `p` would get a relational type of `>` and `+` respectively.  `#!css :has()` relations are actually stored under the selector attributes instead of `relation`, but they still have `rel_type`s as well. In the case of `#!css p:has(> a)`, the `p` selector would have a `Selector` object in the `selectors` tuple with a `rel_type` of `:>` (has relations are prefixed `:` to denote forward looking relations).
+`is_root`  | This is `True` if the current compound selector contains `:is_root`.
 
 ### `SelectorTag`
 
@@ -194,10 +194,10 @@ class SelectorTag(namedtuple('SelectorTag', ['name', 'prefix'])):
     """Selector tag."""
 ```
 
-`SelectorTag`\ Attributes | Description
-------------------------- | -----------
-`name`                    | `name` contains the tag name to match.
-`prefix`                  | `prefix` contains the namespace prefix to match. `prefix` can also be `None`.
+`SelectorTag` | Description
+------------- | -----------
+`name`        | `name` contains the tag name to match.
+`prefix`      | `prefix` contains the namespace prefix to match. `prefix` can also be `None`.
 
 
 ### `SelectorAttribute`
@@ -207,11 +207,11 @@ class SelectorAttribute(namedtuple('AttrRule', ['attribute', 'prefix', 'pattern'
     """Selector attribute rule."""
 ```
 
-`SelectorAttribute`\ Attributes | Description
-------------------------------- | -----------
-`attribute`                     | Contains the attribute name to match.
-`prefix`                        | Contains the attribute namespace prefix to match if any.
-`pattern`                       | Contains a `re` regular expression object that matches the desired attribute value.
+`SelectorAttribute` | Description
+------------------- | -----------
+`attribute`         | Contains the attribute name to match.
+`prefix`            | Contains the attribute namespace prefix to match if any.
+`pattern`           | Contains a `re` regular expression object that matches the desired attribute value.
 
 ### `SelectorNth`
 
@@ -220,13 +220,13 @@ class SelectorNth(namedtuple('SelectorNth', ['a', 'n', 'b', 'type', 'last', 'sel
     """Selector nth type."""
 ```
 
-`SelectorNth`\ Attributes | Description
-------------------------- | -----------
-`a`                       | The `a` value in the formula `an+b` specifying an index.
-`n`                       | `True` if the provided formula has included a literal `n` which signifies the formula is not a static index.
-`b`                       | The `b` value in the formula `an+b`.
-`type`                    | `True` if the `nth` pseudo class is an `*-of-type` variant.
-`last`                    | `True` if the `nth` pseudo class is a `*last*` variant.
-`selectors`               | A tuple of `Selector` objects representing the `of S` portion of `:nth-chld(an+b [of S]?)`.
+`SelectorNth` | Description
+------------- | -----------
+`a`           | The `a` value in the formula `an+b` specifying an index.
+`n`           | `True` if the provided formula has included a literal `n` which signifies the formula is not a static index.
+`b`           | The `b` value in the formula `an+b`.
+`type`        | `True` if the `nth` pseudo class is an `*-of-type` variant.
+`last`        | `True` if the `nth` pseudo class is a `*last*` variant.
+`selectors`   | A tuple of `Selector` objects representing the `of S` portion of `:nth-chld(an+b [of S]?)`.
 
 --8<-- "links.txt"

--- a/docs/src/markdown/about/development.md
+++ b/docs/src/markdown/about/development.md
@@ -158,7 +158,7 @@ A `SelectorList` represents a list of compound selectors.  So if you had the sel
 
 A compound selector gets parsed into pieces. Each part of a specific compound selector is usually assigned to an attribute in a single `Selector` object. The attributes of the `Selector` object may be as simple as a boolean or a string, but they can also be a tuple of of `SelectorList` objects. In the case of `#!css *:not(p, div)`, `#!css *` will be a `SelectorList` with one `Selector`. The `#!css :not(p, div)` selector list will be a tuple containing one `SelectorList` of two `Selectors` (one for `p` and one for `div`) under the `selectors` attribute of the `#!css *` `Selector`.
 
-In short, `Selectors` are always contained within a `SelectorList`, and a compound selector is a single `Selector` object that may chain other `SelectorLists` objects depending on the complexity of the compound selector. If you provide a selector list, than you will get multiple `Selector` objects (one for each compound selector in the list) which in turn may chain other `Selector` objects.
+In short, `Selectors` are always contained within a `SelectorList`, and a compound selector is a single `Selector` object that may chain other `SelectorLists` objects depending on the complexity of the compound selector. If you provide a selector list, then you will get multiple `Selector` objects (one for each compound selector in the list) which in turn may chain other `Selector` objects.
 
 ### `SelectorList`
 
@@ -193,10 +193,10 @@ class Selector:
 `attributes` | Contains a tuple of attributes. Each attribute is represented as a [`SelectorAttribute`](#selectorattribute).
 `nth`        | Contains a tuple containing `nth` selectors, each selector being represented as a [`SelectorNth`](#selectornth). `nth` selectors contain things like `:first-child`, `:only-child`, `#!css :nth-child()`, `#!css :nth-of-type()`, etc.
 `selectors`  | Contains a tuple of `SelectorList` objects for each pseudo class selector  part of the compound selector: `#!css :is()`, `#!css :not()`, `#!css :has()`, etc.
-`empty`   | This is `True` if the current selector contained a `:empty` pseudo.
-`relation`   | This is will contain a `SelectorList` object with one `Selector` object that is a relational match.  For instance, `div > p + a` would be a `Selector` for `a` that contains a `relation` for `p` (another `SelectorList` object) which also contains a relation of `div`.  When matching, we would match that the tag is `a`, and then check that its relations match, in this case a direct, previous sibling of `p`, which has a direct parent of `div`.
-`rel_type`   | `rel_type` is attached to relational selectors. In the case of `#!css div > p + a`, the relational selectors of `div` and `p` would get a relational type of `>` and `+` respectively.  `#!css :has()` relations are actually stored under the selector attributes instead of `relation`, but they still have `rel_type`s as well. In the case of `#!css p:has(> a)`, the `p` selector would have a `Selector` object in the `selectors` tuple with a `rel_type` of `:>` (has relations are prefixed `:` to denote forward looking relations).
-`root`  | This is `True` if the current compound selector contains `:root`.
+`relation`   | This will contain a `SelectorList` object with one `Selector` object, which could in turn chain an additional relation depending on the complexity of the compound selector.  For instance, `div > p + a` would be a `Selector` for `a` that contains a `relation` for `p` (another `SelectorList` object) which also contains a relation of `div`.  When matching, we would match that the tag is `a`, and then walk its relation chain verifying that they all match. In this case, the relation chain would be a direct, previous sibling of `p`, which has a direct parent of `div`. A `:has()` pseudo class would walk this in the opposite order. `div:has(> p + a)` would verify `div`, and then check for a child of `p` with a sibling of `a`.
+`rel_type`   | `rel_type` is attached to relational selectors. In the case of `#!css div > p + a`, the relational selectors of `div` and `p` would get a relational type of `>` and `+` respectively. `:has()` relational `rel_type` are preceded with `:` to signify a forward looking relation.
+`empty`      | This is `True` if the current selector contained a `:empty` pseudo.
+`root`       | This is `True` if the current compound selector contains `:root`.
 
 ### `SelectorTag`
 

--- a/docs/src/markdown/about/development.md
+++ b/docs/src/markdown/about/development.md
@@ -10,16 +10,17 @@ There are a number of files for build, test, and continuous integration in the r
 │       ├── dictionary
 │       └── markdown
 ├── soupsieve
-└── requirements
-
+├── requirements
+└── tests
 ```
 
 Directory             | Description
 --------------------- | -----------
-`docs/src/dictionary` | This contains the spell check wordlist(s) for the project.
-`docs/src/markdown`   | This contains the content for the documentation.
-`soupsieve`           | This contains the source code for the project.
-`requirements`        | This contains files with lists of dependencies that are required for the project, and required for continuous integration.
+`docs/src/dictionary` | Contains the spell check wordlist(s) for the project.
+`docs/src/markdown`   | Contains the content for the documentation.
+`soupsieve`           | Contains the source code for the project.
+`requirements`        | Contains files with lists of dependencies that are required for the project, and required for continuous integration.
+`tests`               | Contains unit test files.
 
 ## Coding Standards
 
@@ -75,7 +76,7 @@ It should print out the files with the misspelled words if any are found.  If yo
 In order to preserve good code health, a test suite has been put together with pytest (@pytest-dev/pytest). There are currently two kinds of tests: syntax and targeted.  To run these tests, you can use the following command:
 
 ```
-python run_tests.py
+py.test
 ```
 
 ### Running Validation With Tox
@@ -125,5 +126,107 @@ coverage erase
 Then run each unit test environment to and coverage will be calculated. All the data from each run is merged together.  HTML is output for each file in `.tox/pyXX/tmp`.  You can use these to see areas that are not covered/exercised yet with testing.
 
 You can checkout `tox.ini` to see how this is accomplished.
+
+## Code Documentation
+
+Soup Sieve is laid out in the following structure:
+
+```
+soupseive
+├── __init__.py
+├── __meta__.py
+├── css_match.py
+├── css_parser.py
+└── util.py
+```
+
+File            | Description
+--------------- | -----------
+`__init__.py`   | Contains the API for the user.
+`__meta__.py`   | Contains package meta data like version.
+`css_match.py`  | Contains the logic for matching tags with a CSS selector.
+`css_parser.py` | Contains the CSS selector parser.
+`util.py`       | Contains miscellaneous helper functions, classes, and constants.
+
+### Compiled CSS Selector Structure
+
+When a CSS selector string is given to Soup Sieve, it is run through the `CSSParser` class.  `CSSParser` will return a tuple object with one or more `Selector` classes. This tuple is handed to the `SoupSieve` class as a parameter along with things like `namespace` and `mode`. One of the most important things to understand when contributing is the structure of the `Selector` class and the various chained objects.
+
+The `Selector` class is a `namedtuple`. A compiled selector will always return a tuple of these objects. A `Selector` represents one compound selector.  So if you had the selector `div > p`, you would get a tuple with one `Selector`. If you had `div, p`, you would get a tuple with two `Selector`s as this is a selector list of two selectors. With that said, `div > p` will generate a sub-selector that is chained to the top level, but at the top level, there is only one.
+
+A compound selector gets parsed into pieces. Each part of a specific compound selector is usually assigned to an attribute in a single `Selector` object, though some attributes can be an tuple of more selectors, as in the case of `*:not(p, div)` where `*` will be one `Selector` with the `:not(p, div)` selector list will be a tuple of containing one tuple of two `Selectors` (one for `p` and one for `div`) under the `selectors` attribute.
+
+In short a compound selector is a single `Selector` object that may chain other `Selector` objects. If you provide a selector list, than you will get multiple `Selector`s (one for each compound selector in the list) which in turn may chain other `Selector` objects.
+
+### `Selector`
+
+```py3
+class Selector(
+    namedtuple(
+        'Selector',
+        [
+            'tag', 'ids', 'classes', 'attributes', 'nth', 'selectors',
+            'is_not', 'is_empty', 'relation', 'rel_type', 'is_root'
+        ]
+    )
+):
+    """Selector."""
+```
+
+`Selector`\ Attributes | Description
+------------           | -----------
+`tag`                  | Contains a single [`SelectorTag`](#selectortag) object, or `None`.
+`id`                   | Contains a tuple of ids to match. Usually if multiple conflicting ids are present, it simply won't match a tag, but it allows multiple to handle the syntax `tag#1#2` even if it is invalid.
+`classes`              | Contains a tuple of class names to match.
+`attributes`           | Contains a tuple of attributes. Each attribute is represented as a [`SelectorAttribute`](#selectorattribute).
+`nth`                  | Contains a tuple containing `nth` selectors, each selector being represented as a [`SelectorNth`](#selectornth). `nth` selectors contain things like `:first-child`, `:only-child`, `:nth-child`, `:nth-of-type`, etc.
+`selectors`            | Contains a tuple of tuples of pseudo class selectors: `:is()`, `:not()`, `:has()`, etc. For instance, for a given selector `div:is(.a, .b):not(.c)`, you would have a tuple of tuples: `((Selector(.a), Selector(.b)), (Selector(.c)))`.
+`is_not`               | This is `True` if the current `Selector` is `:not()` pseudo class.
+`is_empty`             | This is `True` if the current selector contained a `:is_empty` pseudo.
+`relation`             | This is will contain a `Selector` object that is a relational match.  For instance, for `div > p + a` would be a `Selector` that contains a `relation` for `p` (another `Selector` object) which also contains a relation of `div`.  When matching, we would match that the tag is `a`, and then check that it's relations match, in this case a direct, previous sibling of `p` which has a direct parent of `div`.
+`rel_type`             | `rel_type` is attached to relational selectors. In the case of `div > p + a`, the relational selectors of `div` and `p` would get a relational type of `>` and `+` respectively.  `:has()` relations are actually stored under the selector attributes instead of `relation`, but they still have `rel_type`s as well. In the case of `p:has(> a)`, the `p` selector would have a `Selector` object in the `selectors` tuple with a `rel_type` of `:>` (has relations are prefixed `:` to denote forward looking relations).
+`is_root`              | This is `True` if the current compound selector contains `:is_root`.
+
+### `SelectorTag`
+
+```py3
+class SelectorTag(namedtuple('SelectorTag', ['name', 'prefix'])):
+    """Selector tag."""
+```
+
+`SelectorTag`\ Attributes | Description
+------------------------- | -----------
+`name`                    | `name` contains the tag name to match.
+`prefix`                  | `prefix` contains the namespace prefix to match. `prefix` can also be `None`.
+
+
+### `SelectorAttribute`
+
+```py3
+class SelectorAttribute(namedtuple('AttrRule', ['attribute', 'prefix', 'pattern'])):
+    """Selector attribute rule."""
+```
+
+`SelectorAttribute`\ Attributes | Description
+------------------------------- | -----------
+`attribute`                     | Contains the attribute name to match.
+`prefix`                        | Contains the attribute namespace prefix to match if any.
+`pattern`                       | Contains a `re` regular expression object that matches the desired attribute value.
+
+### `SelectorNth`
+
+```py3
+class SelectorNth(namedtuple('SelectorNth', ['a', 'n', 'b', 'type', 'last', 'selectors'])):
+    """Selector nth type."""
+```
+
+`SelectorNth`\ Attributes | Description
+------------------------- | -----------
+`a`                       | The `a` value in the formula `an+b` specifying an index.
+`n`                       | `True` if the provided formula has included a literal `n` which signifies the formula is not a static index.
+`b`                       | The `b` value in the formula `an+b`.
+`type`                    | `True` if the `nth` pseudo class is an `*-of-type` variant.
+`last`                    | `True` if the `nth` pseudo class is a `*last*` variant.
+`selectors`               | A tuple of `Selector` objects representing the `of S` portion of `:nth-chld(an+b [of S]?)`.
 
 --8<-- "links.txt"

--- a/soupsieve/__init__.py
+++ b/soupsieve/__init__.py
@@ -28,6 +28,7 @@ SOFTWARE.
 from .__meta__ import __version__, __version_info__  # noqa: F401
 from . import css_parser as cp
 from . import css_match as cm
+from . import css_types as ct
 from .util import HTML, HTML5, XHTML, XML, deprecated
 
 __all__ = (
@@ -43,9 +44,9 @@ def compile(pattern, namespaces=None, mode=HTML5):  # noqa: A001
     """Compile CSS pattern."""
 
     if namespaces is None:
-        namespaces = cp._Namespaces()
-    if not isinstance(namespaces, cp._Namespaces):
-        namespaces = cp._Namespaces(**(namespaces))
+        namespaces = ct.Namespaces()
+    if not isinstance(namespaces, ct.Namespaces):
+        namespaces = ct.Namespaces(**(namespaces))
 
     if isinstance(pattern, SoupSieve):
         if mode != pattern.mode:

--- a/soupsieve/__init__.py
+++ b/soupsieve/__init__.py
@@ -27,6 +27,7 @@ SOFTWARE.
 """
 from .__meta__ import __version__, __version_info__  # noqa: F401
 from . import css_parser as cp
+from . import css_match as cm
 from .util import HTML, HTML5, XHTML, XML, deprecated
 
 __all__ = (
@@ -35,7 +36,7 @@ __all__ = (
     'comments', 'icomments', 'select', 'iselect', 'match', 'filter'
 )
 
-SoupSieve = cp.SoupSieve
+SoupSieve = cm.SoupSieve
 
 
 def compile(pattern, namespaces=None, mode=HTML5):  # noqa: A001

--- a/soupsieve/__meta__.py
+++ b/soupsieve/__meta__.py
@@ -186,5 +186,5 @@ def parse_version(ver, pre=False):
     return Version(major, minor, micro, release, pre, post, dev)
 
 
-__version_info__ = Version(0, 5, 2, "final")
+__version_info__ = Version(0, 5, 3, "final")
 __version__ = __version_info__._get_canonical()

--- a/soupsieve/css_match.py
+++ b/soupsieve/css_match.py
@@ -403,6 +403,15 @@ class CSSMatch:
 
         return not is_empty or (RE_NOT_EMPTY.search(el.text) is None and not self.has_child(el))
 
+    def match_subselectors(self, el, selectors):
+        """Match selectors."""
+
+        match = True
+        for sel in selectors:
+            if not self.match_selectors(el, sel):
+                match = False
+        return match
+
     def match_selectors(self, el, selectors):
         """Check if element matches one of the selectors."""
 
@@ -430,7 +439,7 @@ class CSSMatch:
             if selector.is_root and not self.match_root(el):
                 continue
             # Verify pseudo selector patterns
-            if selector.selectors and not self.match_selectors(el, selector.selectors):
+            if selector.selectors and not self.match_subselectors(el, selector.selectors):
                 continue
             # Verify relationship selectors
             if selector.relation and not self.match_relations(el, selector.relation):

--- a/soupsieve/css_match.py
+++ b/soupsieve/css_match.py
@@ -160,19 +160,17 @@ class CSSMatch:
             tag.name not in ((util.lower(el.name) if not self.is_xml() else el.name), '*')
         )
 
-    def match_tag(self, el, tags):
+    def match_tag(self, el, tag):
         """Match the tag."""
 
         has_ns = self.supports_namespaces()
         match = True
-        for t in tags:
+        if tag is not None:
             # Verify namespace
-            if has_ns and not self.match_namespace(el, t):
+            if has_ns and not self.match_namespace(el, tag):
                 match = False
-                break
-            if not self.match_tagname(el, t):
+            if not self.match_tagname(el, tag):
                 match = False
-                break
         return match
 
     def match_past_relations(self, el, relation):
@@ -413,7 +411,7 @@ class CSSMatch:
         for selector in selectors:
             match = selector.is_not
             # Verify tag matches
-            if not self.match_tag(el, selector.tags):
+            if not self.match_tag(el, selector.tag):
                 continue
             # Verify `nth` matches
             if not self.match_nth(el, selector.nth):

--- a/soupsieve/css_parser.py
+++ b/soupsieve/css_parser.py
@@ -1,11 +1,9 @@
 """CSS selector parser."""
 import re
-import copyreg
 from collections import namedtuple
 from functools import lru_cache
 from . import util
 from . import css_match as cm
-from .util import deprecated
 
 
 # Selector patterns
@@ -59,8 +57,9 @@ _MAXCACHE = 500
 def _cached_css_compile(pattern, namespaces, mode):
     """Cached CSS compile."""
 
-    return SoupSieve(
+    return cm.SoupSieve(
         pattern,
+        CSSParser(pattern, mode).process_selectors(),
         namespaces,
         mode
     )
@@ -546,105 +545,3 @@ class CSSParser:
         """
 
         return tuple([s.freeze() for s in self.parse_selectors(self.re_sel.finditer(self.pattern))])
-
-
-class SoupSieve(util.Immutable):
-    """Match tags in Beautiful Soup with CSS selectors."""
-
-    __slots__ = ("pattern", "selectors", "namespaces", "mode", "_hash")
-
-    def __init__(self, selectors, namespaces, mode):
-        """Initialize."""
-
-        super().__init__(
-            pattern=selectors,
-            selectors=CSSParser(selectors, mode).process_selectors(),
-            namespaces=namespaces,
-            mode=mode
-        )
-
-    def _walk(self, node, capture=True, comments=False):
-        """Recursively return selected tags."""
-
-        if capture and self.match(node):
-            yield node
-
-        # Walk children
-        for child in node.descendants:
-            if capture and isinstance(child, util.TAG) and self.match(child):
-                yield child
-            elif comments and isinstance(child, util.COMMENT):
-                yield child
-
-    def _sieve(self, node, capture=True, comments=False, limit=0):
-        """Sieve."""
-
-        if limit < 1:
-            limit = None
-
-        for child in self._walk(node, capture, comments):
-            yield child
-            if limit is not None:
-                limit -= 1
-                if limit < 1:
-                    break
-
-    def match(self, node):
-        """Match."""
-
-        return cm.CSSMatch(self.selectors, self.namespaces, self.mode).match(node)
-
-    def filter(self, nodes):  # noqa A001
-        """Filter."""
-
-        if isinstance(nodes, util.TAG):
-            return [node for node in nodes.children if isinstance(node, util.TAG) and self.match(node)]
-        else:
-            return [node for node in nodes if self.match(node)]
-
-    def comments(self, node, limit=0):
-        """Get comments only."""
-
-        return list(self.icomments(node, limit))
-
-    def icomments(self, node, limit=0):
-        """Iterate comments only."""
-
-        yield from self._sieve(node, capture=False, comments=True, limit=limit)
-
-    def select(self, node, limit=0):
-        """Select the specified tags."""
-
-        return list(self.iselect(node, limit))
-
-    def iselect(self, node, limit=0):
-        """Iterate the specified tags."""
-
-        yield from self._sieve(node, limit=limit)
-
-    def __repr__(self):
-        """Representation."""
-
-        return "SoupSieve(pattern=%r, namespaces=%s, mode=%s)" % (self.pattern, self.namespaces, self.mode)
-
-    __str__ = __repr__
-
-    # ====== Deprecated ======
-    @deprecated("Use 'SoupSieve.icomments' instead.")
-    def commentsiter(self, node, limit=0):
-        """Iterate comments only."""
-
-        yield from self.icomments(node, limit)
-
-    @deprecated("Use 'SoupSieve.iselect' instead.")
-    def selectiter(self, node, limit=0):
-        """Iterate the specified tags."""
-
-        yield from self.iselect(node, limit)
-
-
-def _pickle(p):
-    return SoupSieve, (p.pattern, p.namespaces, p.mode)
-
-
-copyreg.pickle(SoupSieve, _pickle)

--- a/soupsieve/css_parser.py
+++ b/soupsieve/css_parser.py
@@ -102,7 +102,7 @@ class _Selector:
     def __init__(self, **kwargs):
         """Initialize."""
 
-        self.tags = kwargs.get('tags', [])
+        self.tag = kwargs.get('tag', None)
         self.ids = kwargs.get('ids', [])
         self.classes = kwargs.get('classes', [])
         self.attributes = kwargs.get('attributes', [])
@@ -139,7 +139,7 @@ class _Selector:
         """Freeze self."""
 
         return Selector(
-            self._freeze_list(self.tags),
+            self.tag,
             self._freeze_list(self.ids),
             self._freeze_list(self.classes),
             self._freeze_list(self.attributes),
@@ -156,10 +156,10 @@ class _Selector:
         """String representation."""
 
         return (
-            '_Selector(tags=%r, ids=%r, classes=%r, attributes=%r, nth=%r, selectors=%r, '
+            '_Selector(tag=%r, ids=%r, classes=%r, attributes=%r, nth=%r, selectors=%r, '
             'is_not=%r, relation=%r, rel_type=%r, is_root=%r)'
         ) % (
-            self.tags, self.ids, self.classes, self.attributes, self.nth, self.selectors,
+            self.tag, self.ids, self.classes, self.attributes, self.nth, self.selectors,
             self.is_not, self.relation, self.rel_type, self.is_root
         )
 
@@ -170,7 +170,7 @@ class Selector(
     namedtuple(
         'Selector',
         [
-            'tags', 'ids', 'classes', 'attributes', 'nth', 'selectors',
+            'tag', 'ids', 'classes', 'attributes', 'nth', 'selectors',
             'is_not', 'is_empty', 'relation', 'rel_type', 'is_root'
         ]
     )
@@ -263,7 +263,7 @@ class CSSParser:
         else:
             tag = parts[0]
             prefix = None
-        sel.tags.append(SelectorTag(tag, prefix))
+        sel.tag = SelectorTag(tag, prefix)
         has_selector = True
         return has_selector
 
@@ -401,9 +401,9 @@ class CSSParser:
             raise ValueError("Cannot start or end selector with '{}'".format(m.group('relation')))
         is_not = sel.is_not
         if m.group('relation') == SPLIT:
-            if not sel.tags and not is_pseudo:
+            if not sel.tag and not is_pseudo:
                 # Implied `*`
-                sel.tags.append(SelectorTag('*', None))
+                sel.tag = SelectorTag('*', None)
             sel.relation = relations[0] if relations else None
             selectors.append(sel)
             relations.clear()
@@ -415,14 +415,14 @@ class CSSParser:
             # In the case of `:not(el1) > el2`, where the ancestor is evaluated with a not, you'd actually get:
             # ```
             # _Selector(
-            #     tags=['el2'],
+            #     tag = 'el2',
             #     relations=[
             #         [
             #             _Selector(
-            #                 tags=['*'],
+            #                 tag = '*',
             #                 selectors=[
             #                     _Selector(
-            #                         tags=['el1'],
+            #                         tag = 'el1',
             #                         is_not=True
             #                     )
             #                 ]
@@ -519,9 +519,9 @@ class CSSParser:
             raise ValueError("Cannot end with a combining character")
 
         if has_selector:
-            if not sel.tags and not is_pseudo:
+            if not sel.tag and not is_pseudo:
                 # Implied `*`
-                sel.tags.append(SelectorTag('*', None))
+                sel.tag = SelectorTag('*', None)
             if is_has:
                 sel.rel_type = rel_type
                 selectors[-1].set_distant_relation(sel)

--- a/soupsieve/css_parser.py
+++ b/soupsieve/css_parser.py
@@ -363,7 +363,7 @@ class CSSParser:
     def parse_pseudo_open(self, sel, m, has_selector, iselector, is_pseudo):
         """Parse pseudo with opening bracket."""
 
-        sel.selectors.extend(
+        sel.selectors.append(
             self.parse_selectors(
                 iselector,
                 True,

--- a/soupsieve/css_parser.py
+++ b/soupsieve/css_parser.py
@@ -7,7 +7,7 @@ from . import css_match as cm
 
 
 # Selector patterns
-CSS_ESCAPES = r'(?:\\[a-fA-F0-9]{1,6}[ ]?|\\.)'
+CSS_ESCAPES = r'(?:\\[a-f0-9]{1,6}[ ]?|\\.)'
 
 NTH = r'(?:[-+])?(?:\d+n?|n)(?:(?<=n)\s*(?:[-+])\s*(?:\d+))?'
 
@@ -32,20 +32,20 @@ SELECTORS = r'''(?x)
     {doc_specific}
     (?:\s*(?P<cmp>[~^|*$]?=)\s*                                                   # compare
     (?P<value>"(\\.|[^\\"]+)*?"|'(\\.|[^\\']+)*?'|(?:[^'"\[\] \t\r\n]|{esc})+))?  # attribute value
-    (?P<case>[ ]+[iIsS])?\s*\] |                                                  # case sensitivity
+    (?P<case>[ ]+[is])?\s*\] |                                                    # case sensitivity
     (?P<pseudo_close>\)) |                                                        # optional pseudo selector close
     (?P<split>\s*?(?P<relation>[,+>~]|[ ](?![,+>~]))\s*) |                        # split multiple selectors
     (?P<invalid>).+                                                               # not proper syntax
 '''
 
-RE_HTML_SEL = re.compile(SELECTORS.format(esc=CSS_ESCAPES, nth=NTH, doc_specific=HTML_SELECTORS))
-RE_XML_SEL = re.compile(SELECTORS.format(esc=CSS_ESCAPES, nth=NTH, doc_specific=XML_SELECTORS))
+RE_HTML_SEL = re.compile(SELECTORS.format(esc=CSS_ESCAPES, nth=NTH, doc_specific=HTML_SELECTORS), re.I)
+RE_XML_SEL = re.compile(SELECTORS.format(esc=CSS_ESCAPES, nth=NTH, doc_specific=XML_SELECTORS), re.I)
 
 # CSS escape pattern
-RE_CSS_ESC = re.compile(r'(?:(\\[a-fA-F0-9]{1,6}[ ]?)|(\\.))')
+RE_CSS_ESC = re.compile(r'(?:(\\[a-f0-9]{1,6}[ ]?)|(\\.))', re.I)
 
 # Pattern to break up `nth` specifiers
-RE_NTH = re.compile(r'(?P<s1>[-+])?(?P<a>\d+n?|n)(?:(?<=n)\s*(?P<s2>[-+])\s*(?P<b>\d+))?')
+RE_NTH = re.compile(r'(?P<s1>[-+])?(?P<a>\d+n?|n)(?:(?<=n)\s*(?P<s2>[-+])\s*(?P<b>\d+))?', re.I)
 
 SPLIT = ','
 HAS_CHILD = ": "

--- a/soupsieve/css_types.py
+++ b/soupsieve/css_types.py
@@ -1,0 +1,131 @@
+"""CSS selector structure items."""
+from . import util
+import copyreg
+
+__all__ = ('Selector', 'SelectorTag', 'SelectorAttribute', 'SelectorNth', 'SelectorList', 'Namespaces')
+
+
+class Namespaces(util.ImmutableDict):
+    """Namespaces."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize."""
+
+        if not all([isinstance(k, str) and isinstance(v, str) for k, v in args]):
+            raise TypeError('Namespace keys and values must be Unicode strings')
+        if not all([isinstance(k, str) and isinstance(v, str) for k, v in kwargs.items()]):
+            raise TypeError('Namespace keys and values must be Unicode strings')
+
+        super().__init__(*args, **kwargs)
+
+
+class Selector(util.Immutable):
+    """Selector."""
+
+    __slots__ = (
+        'tag', 'ids', 'classes', 'attributes', 'nth', 'selectors',
+        'relation', 'rel_type', 'empty', 'root', '_hash'
+    )
+
+    def __init__(self, tag, ids, classes, attributes, nth, selectors, relation, rel_type, empty, root):
+        """Initialize."""
+
+        super().__init__(
+            tag=tag,
+            ids=ids,
+            classes=classes,
+            attributes=attributes,
+            nth=nth,
+            selectors=selectors,
+            relation=relation,
+            rel_type=rel_type,
+            empty=empty,
+            root=root
+        )
+
+
+class SelectorTag(util.Immutable):
+    """Selector tag."""
+
+    __slots__ = ("name", "prefix", "_hash")
+
+    def __init__(self, name, prefix):
+        """Initialize."""
+
+        super().__init__(
+            name=name,
+            prefix=prefix
+        )
+
+
+class SelectorAttribute(util.Immutable):
+    """Selector attribute rule."""
+
+    __slots__ = ("attribute", "prefix", "pattern", "_hash")
+
+    def __init__(self, attribute, prefix, pattern):
+        """Initialize."""
+
+        super().__init__(
+            attribute=attribute,
+            prefix=prefix,
+            pattern=pattern
+        )
+
+
+class SelectorNth(util.Immutable):
+    """Selector nth type."""
+
+    __slots__ = ("a", "n", "b", "of_type", "last", "selectors", "_hash")
+
+    def __init__(self, a, n, b, of_type, last, selectors):
+        """Initialize."""
+
+        super().__init__(
+            a=a,
+            n=n,
+            b=b,
+            of_type=of_type,
+            last=last,
+            selectors=selectors
+        )
+
+
+class SelectorList(util.Immutable):
+    """Selector list."""
+
+    __slots__ = ("_selectors", "is_not", "_hash")
+
+    def __init__(self, selectors=tuple(), is_not=False):
+        """Initialize."""
+
+        super().__init__(
+            _selectors=tuple(selectors),
+            is_not=is_not
+        )
+
+    def __iter__(self):
+        """Iterator."""
+
+        return iter(self._selectors)
+
+    def __len__(self):
+        """Length."""
+
+        return len(self._selectors)
+
+    def __getitem__(self, index):
+        """Get item."""
+
+        return self._selectors[index]
+
+
+def _pickle(p):
+    return p.__base__(), tuple([getattr(p, s) for s in p.__slots__[:-1]])
+
+
+copyreg.pickle(Selector, _pickle)
+copyreg.pickle(SelectorTag, _pickle)
+copyreg.pickle(SelectorAttribute, _pickle)
+copyreg.pickle(SelectorNth, _pickle)
+copyreg.pickle(SelectorList, _pickle)

--- a/tests/test_level4.py
+++ b/tests/test_level4.py
@@ -171,6 +171,33 @@ class TestLevel4(util.TestCase):
             mode=sv.HTML5
         )
 
+        # Each pseudo class is evaluated separately
+        # So this will not match
+        self.assert_selector(
+            markup,
+            ":is(span):not(span)",
+            [],
+            mode=sv.HTML5
+        )
+
+        # Each pseudo class is evaluated separately
+        # So this will not match
+        self.assert_selector(
+            markup,
+            ":is(span):is(div)",
+            [],
+            mode=sv.HTML5
+        )
+
+        # Each pseudo class is evaluated separately
+        # So this will match
+        self.assert_selector(
+            markup,
+            ":is(a):is(#2)",
+            ['2'],
+            mode=sv.HTML5
+        )
+
     def test_multi_nested_not(self):
         """Test nested not and multiple selectors."""
 

--- a/tests/test_soupsieve.py
+++ b/tests/test_soupsieve.py
@@ -6,6 +6,7 @@ import copy
 import random
 import pytest
 import warnings
+import pickle
 
 
 class TestSoupSieve(unittest.TestCase):
@@ -121,22 +122,35 @@ class TestSoupSieve(unittest.TestCase):
         self.assertEqual(len(nodes), 1)
         self.assertEqual(nodes[0].attrs['id'], '6')
 
-    def test_cache(self):
-        """Test copy."""
+    def test_copy_pickle(self):
+        """Test copy and pickle."""
 
+        # Test that we can pickle and unpickle
         p1 = sv.compile('p[id]', mode=sv.HTML5)
-        p2 = sv.compile('p[id]', mode=sv.HTML5)
-        p3 = sv.compile('p[id]', mode=sv.HTML)
-        p4 = copy.copy(p1)
-        p5 = copy.copy(p3)
+        sp1 = pickle.dumps(p1)
+        pp1 = pickle.loads(sp1)
+        self.assertTrue(pp1 == p1)
 
+        # Test that we pull the same one from cache
+        p2 = sv.compile('p[id]', mode=sv.HTML5)
         self.assertTrue(p1 is p2)
+
+        # Test that we compile a new one when providing a different mode
+        p3 = sv.compile('p[id]', mode=sv.HTML)
         self.assertTrue(p1 is not p3)
+
+        # Test that the copy is equivalent, but not same.
+        p4 = copy.copy(p1)
         self.assertTrue(p4 is not p1)
         self.assertTrue(p4 == p1)
+
+        p5 = copy.copy(p3)
         self.assertTrue(p5 is not p3)
         self.assertTrue(p5 == p3)
         self.assertTrue(p5 is not p4)
+
+    def test_cache(self):
+        """Test cache."""
 
         sv.purge()
         self.assertEqual(sv.cp._cached_css_compile.cache_info().currsize, 0)


### PR DESCRIPTION
While doing a write up of the compiled selector structure, it was noticed that some things needed to be refactored. But further into it, it was realized that the way we handle pseudo classes was a bit wrong. We were handling them all as one big list, but really we needed each pseudo class's selector list to be handled individually. This has been fixed, along with ensuring that all CSS selector tokens are case insensitive. 