### PR TITLE
Select matches children of a given tag, not the tag itself

### DIFF
--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.1
+
+- **FIX**: When giving a tag to `select`, it should only return the children of that tag, never the tag itself.
+- **FIX**: For informational purposes, raise a `NotImplementedError` when an unsupported pseudo class is used.
+
 ## 1.0.0
 
 - **NEW**: Official 1.0.0 release.

--- a/soupsieve/__meta__.py
+++ b/soupsieve/__meta__.py
@@ -186,5 +186,5 @@ def parse_version(ver, pre=False):
     return Version(major, minor, micro, release, pre, post, dev)
 
 
-__version_info__ = Version(1, 0, 0, "final")
+__version_info__ = Version(1, 0, 1, "final")
 __version__ = __version_info__._get_canonical()

--- a/soupsieve/css_match.py
+++ b/soupsieve/css_match.py
@@ -496,9 +496,6 @@ class SoupSieve(util.Immutable):
     def _walk(self, node, capture=True, comments=False):
         """Recursively return selected tags."""
 
-        if capture and self.match(node):
-            yield node
-
         # Walk children
         for child in node.descendants:
             if capture and isinstance(child, util.TAG) and self.match(child):

--- a/soupsieve/css_parser.py
+++ b/soupsieve/css_parser.py
@@ -48,6 +48,8 @@ PAT_PSEUDO_NTH_TYPE = r'''(?x)
 
 PAT_SPLIT = r'{ws}*?(?P<relation>[,+>~]|{ws}(?![,+>~])){ws}*'.format(ws=WS)
 
+PAT_INVALID_PSEUDO = r':[a-z0-9-]+'
+
 # Extra selector patterns
 PAT_CONTAINS = r':contains\({ws}*{value}{ws}*\)'.format(ws=WS, value=VALUE)
 
@@ -181,6 +183,7 @@ class CSSParser:
             ("contains", SelectorPattern(PAT_CONTAINS)),
             ("pseudo_nth_child", SelectorPattern(PAT_PSEUDO_NTH_CHILD)),
             ("pseudo_nth_type", SelectorPattern(PAT_PSEUDO_NTH_TYPE)),
+            ("pseudo_invalid", SelectorPattern(PAT_INVALID_PSEUDO)),
             ("id", SelectorPattern(PAT_ID)),
             ("class", SelectorPattern(PAT_CLASS)),
             ("tag", SelectorPattern(PAT_TAG)),
@@ -463,7 +466,9 @@ class CSSParser:
                 key, m = next(iselector)
 
                 # Handle parts
-                if key == 'pseudo':
+                if key == 'pseudo_invalid':
+                    raise NotImplementedError("'{}' pseudo class is not implemented".format(m.group(0)))
+                elif key == 'pseudo':
                     has_selector = self.parse_pseudo(sel, m, has_selector)
                 elif key == 'contains':
                     has_selector = self.parse_contains(sel, m, has_selector)

--- a/tests/test_soupsieve.py
+++ b/tests/test_soupsieve.py
@@ -74,7 +74,7 @@ class TestSoupSieve(unittest.TestCase):
 
         span = sv.select('span[id]', soup)[0]
         ids = []
-        for el in sv.select('span[id]', span):
+        for el in sv.select('span[id]:not(#some-id)', span.parent):
             ids.append(el.attrs['id'])
 
         self.assertEqual(sorted(['5']), sorted(ids))
@@ -363,6 +363,12 @@ class TestInvalid(unittest.TestCase):
 
         with self.assertRaises(SyntaxError):
             sv.compile('div >')
+
+    def test_invalid_pseudo(self):
+        """Test invalid pseudo class."""
+
+        with self.assertRaises(NotImplementedError):
+            sv.compile(':before')
 
     def test_invalid_pseudo_close(self):
         """Test invalid pseudo close."""


### PR DESCRIPTION
Also raise NotImplementedError for unsupported pseudo classes.

I knew I was going to find something as soon as I released it....