### PR TITLE
1.1.0dev0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Patches
+*.patch

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ filtering with using modern CSS selectors.
 While Beautiful Soup comes with a builtin CSS selection API, it is not without issues. In addition, it also lacks
 support for some more modern CSS features.
 
-Soup Sieve supports a subset of CSS4 selectors which allows for filtering of tags in a Beautiful Soup object. Soup
-Sieve does not attempt to support all CSS4 selectors as many don't make sense in a non-browser environment. Some of the
-supported selectors are:
+Soup Sieve implements most of the CSS4 selectors, though there are a number that don't make sense in a non-browser
+environment. Selectors that cannot provide meaningful functionality simply do not match anything. Some of the supported
+selectors are:
 
 - `.classes`
 - `#ids`

--- a/docs/src/dictionary/en-custom.txt
+++ b/docs/src/dictionary/en-custom.txt
@@ -27,6 +27,7 @@ html
 iterable
 linter
 lxml
+matchable
 matcher
 matchers
 namespace
@@ -42,5 +43,6 @@ tuple
 tuples
 un
 unpickle
+unvisited
 whitespace
 wordlist

--- a/docs/src/dictionary/en-custom.txt
+++ b/docs/src/dictionary/en-custom.txt
@@ -42,6 +42,7 @@ substring
 tuple
 tuples
 un
+unmatchable
 unpickle
 unvisited
 whitespace

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -6,6 +6,7 @@
 - **NEW**: Add support for `:active`, `:focus`, `:hover`, `:visited`, `:target`, `:focus-within`, `:focus-visible`, `:target-within`, `:current()`/`:current`, `:past`, and `:future`, but they will never match as these states don't exist in the Soup Sieve environment.
 - **NEW**: Add support for `:checked`, `:enabled`, `:disabled`, `:required`, `:optional`, and `:default` which will only match in HTML documents as these concepts are not defined in XML.
 - **NEW**: Add support for `:link` and `:any-link`, both of which will target all `<a>`, `<area>`, and `<link>` elements with an `href` attribute as all links will be treated as unvisited in Soup Sieve.
+- **FIX**: Attributes in the form `prefix:attr` can be matched with the form `[prefix\:attr]` without specifying a namespaces if desired.
 
 ## 1.0.2
 

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.1.0
+
+- **NEW**: Adds support for `[attr!=value]` which is equivalent to `:not([attr=value])`.
+
 ## 1.0.2
 
 - **FIX**: Use proper CSS identifier patterns for tag names, classes, ids, etc. Things like `#3` or `#-3` should not match and should require `#\33` or `#-\33`.

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -4,7 +4,7 @@
 
 - **NEW**: Adds support for `[attr!=value]` which is equivalent to `:not([attr=value])`.
 - **NEW**: Add support for `:active`, `:focus`, `:hover`, `:visited`, `:target`, `:focus-within`, `:focus-visible`, `:target-within`, `:current()`/`:current`, `:past`, and `:future`, but they will never match as these states don't exist in the Soup Sieve environment.
-- **NEW**: Add support for `:checked`, `:enabled`, `:disabled` which will only match in HTML documents as these concepts are not defined in XML.
+- **NEW**: Add support for `:checked`, `:enabled`, `:disabled`, `:required`, and `:optional` which will only match in HTML documents as these concepts are not defined in XML.
 - **NEW**: Add support for `:link` and `:any-link`, both of which will target all `<a>`, `<area>`, and `<link>` elements with an `href` attribute as all links will be treated as unvisited in Soup Sieve.
 
 ## 1.0.2

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -3,7 +3,7 @@
 ## 1.1.0
 
 - **NEW**: Adds support for `[attr!=value]` which is equivalent to `:not([attr=value])`.
-- **NEW**: Add support for `:active`, `:focus`, `:hover`, `:visited`, `:target`, `:focus-within`, `:focus-visible`, `:target-within`, `:placeholder-shown`, `:current()`/`:current`, `:past`, and `:future`, but they will never match as these states don't exist in the Soup Sieve environment.
+- **NEW**: Add support for `:active`, `:focus`, `:hover`, `:visited`, `:target`, `:focus-within`, `:focus-visible`, `:target-within`, `:lang()`, `:placeholder-shown`, `:current()`/`:current`, `:past`, and `:future`, but they will never match as these states don't exist in the Soup Sieve environment.
 - **NEW**: Add support for `:checked`, `:enabled`, `:disabled`, `:required`, `:optional`, and `:default` which will only match in HTML documents as these concepts are not defined in XML.
 - **NEW**: Add support for `:link` and `:any-link`, both of which will target all `<a>`, `<area>`, and `<link>` elements with an `href` attribute as all links will be treated as unvisited in Soup Sieve.
 - **FIX**: Attributes in the form `prefix:attr` can be matched with the form `[prefix\:attr]` without specifying a namespaces if desired.

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -3,6 +3,9 @@
 ## 1.1.0
 
 - **NEW**: Adds support for `[attr!=value]` which is equivalent to `:not([attr=value])`.
+- **NEW**: Add support for `:active`, `:focus`, `:hover`, `:visited`, and `:target`, but they will never match as these states don't exist in the Soup Sieve environment.
+- **NEW**: Add support for `:checked`, `:enabled`, `:disabled` which will only match in HTML documents as these concepts are not defined in XML.
+- **NEW**: Add support for `:link` and `:any-link`, both of which will target all `<a>`, `<area>`, and `<link>` elements with an `href` attribute as all links will be treated as unvisited in Soup Sieve.
 
 ## 1.0.2
 

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -3,10 +3,11 @@
 ## 1.1.0
 
 - **NEW**: Adds support for `[attr!=value]` which is equivalent to `:not([attr=value])`.
-- **NEW**: Add support for `:active`, `:focus`, `:hover`, `:visited`, `:target`, `:focus-within`, `:focus-visible`, `:target-within`, `:current()`/`:current`, `:past`, and `:future`, but they will never match as these states don't exist in the Soup Sieve environment.
+- **NEW**: Add support for `:active`, `:focus`, `:hover`, `:visited`, `:target`, `:focus-within`, `:focus-visible`, `:target-within`, `:placeholder-shown`, `:current()`/`:current`, `:past`, and `:future`, but they will never match as these states don't exist in the Soup Sieve environment.
 - **NEW**: Add support for `:checked`, `:enabled`, `:disabled`, `:required`, `:optional`, and `:default` which will only match in HTML documents as these concepts are not defined in XML.
 - **NEW**: Add support for `:link` and `:any-link`, both of which will target all `<a>`, `<area>`, and `<link>` elements with an `href` attribute as all links will be treated as unvisited in Soup Sieve.
 - **FIX**: Attributes in the form `prefix:attr` can be matched with the form `[prefix\:attr]` without specifying a namespaces if desired.
+- **FIX**: Fix exception when `[type]` is used (with no value).
 
 ## 1.0.2
 

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -3,9 +3,10 @@
 ## 1.1.0
 
 - **NEW**: Adds support for `[attr!=value]` which is equivalent to `:not([attr=value])`.
-- **NEW**: Add support for `:active`, `:focus`, `:hover`, `:visited`, `:target`, `:focus-within`, `:focus-visible`, `:target-within`, `:lang()`, `:placeholder-shown`, `:current()`/`:current`, `:past`, and `:future`, but they will never match as these states don't exist in the Soup Sieve environment.
-- **NEW**: Add support for `:checked`, `:enabled`, `:disabled`, `:required`, `:optional`, and `:default` which will only match in HTML documents as these concepts are not defined in XML.
+- **NEW**: Add support for `:active`, `:focus`, `:hover`, `:visited`, `:target`, `:focus-within`, `:focus-visible`, `:target-within`, `:current()`/`:current`, `:past`, and `:future`, but they will never match as these states don't exist in the Soup Sieve environment.
+- **NEW**: Add support for `:checked`, `:enabled`, `:disabled`, `:required`, `:optional`, `:default`, and `:placeholder-shown` which will only match in HTML documents as these concepts are not defined in XML.
 - **NEW**: Add support for `:link` and `:any-link`, both of which will target all `<a>`, `<area>`, and `<link>` elements with an `href` attribute as all links will be treated as unvisited in Soup Sieve.
+- **NEW**: Add support for `:lang()` (CSS4) which works in XML and HTML.
 - **FIX**: Attributes in the form `prefix:attr` can be matched with the form `[prefix\:attr]` without specifying a namespaces if desired.
 - **FIX**: Fix exception when `[type]` is used (with no value).
 

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -4,7 +4,7 @@
 
 - **NEW**: Adds support for `[attr!=value]` which is equivalent to `:not([attr=value])`.
 - **NEW**: Add support for `:active`, `:focus`, `:hover`, `:visited`, `:target`, `:focus-within`, `:focus-visible`, `:target-within`, `:current()`/`:current`, `:past`, and `:future`, but they will never match as these states don't exist in the Soup Sieve environment.
-- **NEW**: Add support for `:checked`, `:enabled`, `:disabled`, `:required`, and `:optional` which will only match in HTML documents as these concepts are not defined in XML.
+- **NEW**: Add support for `:checked`, `:enabled`, `:disabled`, `:required`, `:optional`, and `:default` which will only match in HTML documents as these concepts are not defined in XML.
 - **NEW**: Add support for `:link` and `:any-link`, both of which will target all `<a>`, `<area>`, and `<link>` elements with an `href` attribute as all links will be treated as unvisited in Soup Sieve.
 
 ## 1.0.2

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -3,7 +3,7 @@
 ## 1.1.0
 
 - **NEW**: Adds support for `[attr!=value]` which is equivalent to `:not([attr=value])`.
-- **NEW**: Add support for `:active`, `:focus`, `:hover`, `:visited`, and `:target`, but they will never match as these states don't exist in the Soup Sieve environment.
+- **NEW**: Add support for `:active`, `:focus`, `:hover`, `:visited`, `:target`, `:focus-within`, `:focus-visible`, `:target-within`, `:current()`/`:current`, `:past`, and `:future`, but they will never match as these states don't exist in the Soup Sieve environment.
 - **NEW**: Add support for `:checked`, `:enabled`, `:disabled` which will only match in HTML documents as these concepts are not defined in XML.
 - **NEW**: Add support for `:link` and `:any-link`, both of which will target all `<a>`, `<area>`, and `<link>` elements with an `href` attribute as all links will be treated as unvisited in Soup Sieve.
 

--- a/docs/src/markdown/about/development.md
+++ b/docs/src/markdown/about/development.md
@@ -196,6 +196,7 @@ Attribute    | Description
 `rel_type`   | `rel_type` is attached to relational selectors. In the case of `#!css div > p + a`, the relational selectors of `div` and `p` would get a relational type of `>` and `+` respectively. `:has()` relational `rel_type` are preceded with `:` to signify a forward looking relation.
 `empty`      | This is `True` if the current selector contained a `:empty` pseudo.
 `root`       | This is `True` if the current compound selector contains `:root`.
+`default`    | This selector is a `:default` pattern  and requires additional logic to determine if it is the first `submit` button in a form.
 `no_match`   | This compound selector has an unmatchable selector, such as `:focus`. Such selectors cannot match as certain states are not applicable to Soup Sieve.
 
 ### `SelectorTag`

--- a/docs/src/markdown/about/development.md
+++ b/docs/src/markdown/about/development.md
@@ -171,7 +171,8 @@ class SelectorList:
 Attribute      | Description
 -------------- | -----------
 `selectors`    | A list of `Selector` objects.
-`is_not`       | Are the selectors in the selector list from a `:not()`.
+`is_not`       | The selectors in the selector list are from a `:not()`.
+`is_html`      | The selectors in the selector list are HTML specific.
 
 ### `Selector`
 
@@ -195,6 +196,7 @@ Attribute    | Description
 `rel_type`   | `rel_type` is attached to relational selectors. In the case of `#!css div > p + a`, the relational selectors of `div` and `p` would get a relational type of `>` and `+` respectively. `:has()` relational `rel_type` are preceded with `:` to signify a forward looking relation.
 `empty`      | This is `True` if the current selector contained a `:empty` pseudo.
 `root`       | This is `True` if the current compound selector contains `:root`.
+`no_match`   | This selector has an unmatchable selector, such as `:focus`. Such selectors cannot match as certain states are not applicable to Soup Sieve.
 
 ### `SelectorTag`
 

--- a/docs/src/markdown/about/development.md
+++ b/docs/src/markdown/about/development.md
@@ -196,7 +196,7 @@ Attribute    | Description
 `rel_type`   | `rel_type` is attached to relational selectors. In the case of `#!css div > p + a`, the relational selectors of `div` and `p` would get a relational type of `>` and `+` respectively. `:has()` relational `rel_type` are preceded with `:` to signify a forward looking relation.
 `empty`      | This is `True` if the current selector contained a `:empty` pseudo.
 `root`       | This is `True` if the current compound selector contains `:root`.
-`no_match`   | This selector has an unmatchable selector, such as `:focus`. Such selectors cannot match as certain states are not applicable to Soup Sieve.
+`no_match`   | This compound selector has an unmatchable selector, such as `:focus`. Such selectors cannot match as certain states are not applicable to Soup Sieve.
 
 ### `SelectorTag`
 

--- a/docs/src/markdown/about/development.md
+++ b/docs/src/markdown/about/development.md
@@ -180,24 +180,31 @@ Attribute      | Description
 class Selector:
     """Selector."""
 
-    def __init__(self, tag, ids, classes, attributes, nth, selectors, relation, rel_type, empty, root):
+    def __init__(
+        self, tag, ids, classes, attributes, nth, selectors, relation,
+        rel_type, contains, lang, empty, root, default, indeterminate,
+        no_match
+    ):
         """Initialize."""
 ```
 
-Attribute    | Description
------------- | -----------
-`tag`        | Contains a single [`SelectorTag`](#selectortag) object, or `None`.
-`id`         | Contains a tuple of ids to match. Usually if multiple conflicting ids are present, it simply won't match a tag, but it allows multiple to handle the syntax `tag#1#2` even if it is invalid.
-`classes`    | Contains a tuple of class names to match.
-`attributes` | Contains a tuple of attributes. Each attribute is represented as a [`SelectorAttribute`](#selectorattribute).
-`nth`        | Contains a tuple containing `nth` selectors, each selector being represented as a [`SelectorNth`](#selectornth). `nth` selectors contain things like `:first-child`, `:only-child`, `#!css :nth-child()`, `#!css :nth-of-type()`, etc.
-`selectors`  | Contains a tuple of `SelectorList` objects for each pseudo class selector  part of the compound selector: `#!css :is()`, `#!css :not()`, `#!css :has()`, etc.
-`relation`   | This will contain a `SelectorList` object with one `Selector` object, which could in turn chain an additional relation depending on the complexity of the compound selector.  For instance, `div > p + a` would be a `Selector` for `a` that contains a `relation` for `p` (another `SelectorList` object) which also contains a relation of `div`.  When matching, we would match that the tag is `a`, and then walk its relation chain verifying that they all match. In this case, the relation chain would be a direct, previous sibling of `p`, which has a direct parent of `div`. A `:has()` pseudo class would walk this in the opposite order. `div:has(> p + a)` would verify `div`, and then check for a child of `p` with a sibling of `a`.
-`rel_type`   | `rel_type` is attached to relational selectors. In the case of `#!css div > p + a`, the relational selectors of `div` and `p` would get a relational type of `>` and `+` respectively. `:has()` relational `rel_type` are preceded with `:` to signify a forward looking relation.
-`empty`      | This is `True` if the current selector contained a `:empty` pseudo.
-`root`       | This is `True` if the current compound selector contains `:root`.
-`default`    | This selector is a `:default` pattern  and requires additional logic to determine if it is the first `submit` button in a form.
-`no_match`   | This compound selector has an unmatchable selector, such as `:focus`. Such selectors cannot match as certain states are not applicable to Soup Sieve.
+Attribute       | Description
+--------------- | -----------
+`tag`           | Contains a single [`SelectorTag`](#selectortag) object, or `None`.
+`id`            | Contains a tuple of ids to match. Usually if multiple conflicting ids are present, it simply won't match a tag, but it allows multiple to handle the syntax `tag#1#2` even if it is invalid.
+`classes`       | Contains a tuple of class names to match.
+`attributes`    | Contains a tuple of attributes. Each attribute is represented as a [`SelectorAttribute`](#selectorattribute).
+`nth`           | Contains a tuple containing `nth` selectors, each selector being represented as a [`SelectorNth`](#selectornth). `nth` selectors contain things like `:first-child`, `:only-child`, `#!css :nth-child()`, `#!css :nth-of-type()`, etc.
+`selectors`     | Contains a tuple of `SelectorList` objects for each pseudo class selector  part of the compound selector: `#!css :is()`, `#!css :not()`, `#!css :has()`, etc.
+`relation`      | This will contain a `SelectorList` object with one `Selector` object, which could in turn chain an additional relation depending on the complexity of the compound selector.  For instance, `div > p + a` would be a `Selector` for `a` that contains a `relation` for `p` (another `SelectorList` object) which also contains a relation of `div`.  When matching, we would match that the tag is `a`, and then walk its relation chain verifying that they all match. In this case, the relation chain would be a direct, previous sibling of `p`, which has a direct parent of `div`. A `:has()` pseudo class would walk this in the opposite order. `div:has(> p + a)` would verify `div`, and then check for a child of `p` with a sibling of `a`.
+`rel_type`      | `rel_type` is attached to relational selectors. In the case of `#!css div > p + a`, the relational selectors of `div` and `p` would get a relational type of `>` and `+` respectively. `:has()` relational `rel_type` are preceded with `:` to signify a forward looking relation.
+`contains`      | Contains a tuple of strings of content to match in an element.
+`lang`          | Contains a tuple of [`SelectorLang`](#selectorlang) objects.
+`empty`         | This is `True` if the current selector contained a `:empty` pseudo.
+`root`          | This is `True` if the current compound selector contains `:root`.
+`default`       | This compound selector has a `:default` pattern  and requires additional logic to determine if it is the first `submit` button in a form.
+`indeterminate` | This compound selector has a `:indeterminate` pattern and requires additional logic to ensure a `radio` element and all of the `radio` elements with the same `name` under a form are not set.
+`no_match`      | This compound selector has an unmatchable selector, such as `:focus`. Such selectors cannot match as certain states are not applicable to Soup Sieve.
 
 ### `SelectorTag`
 
@@ -250,5 +257,19 @@ Attribute     | Description
 `type`        | `True` if the `nth` pseudo class is an `*-of-type` variant.
 `last`        | `True` if the `nth` pseudo class is a `*last*` variant.
 `selectors`   | A `SelectorList` object representing the `of S` portion of `:nth-chld(an+b [of S]?)`.
+
+### `SelectorLang`
+
+```py3
+class SelectorLang:
+    """Selector language rules."""
+
+    def __init__(self, languages):
+        """Initialize."""
+```
+
+Attribute     | Description
+------------- | -----------
+`languages`  | A list of regular expression objects that match a language pattern.
 
 --8<-- "links.txt"

--- a/docs/src/markdown/index.md
+++ b/docs/src/markdown/index.md
@@ -6,7 +6,7 @@ Soup Sieve is a CSS selector library designed to be used with [Beautiful Soup 4]
 
 While Beautiful Soup comes with a builtin CSS selection API, it is not without issues. In addition, it also lacks support for some more modern CSS features.
 
-Sieve does not attempt to support all CSS4 selectors as many don't make sense in a non-browser environment. Some of the supported selectors are:
+Soup Sieve implements most of the CSS4 selectors, though there are a number that don't make sense in a non-browser environment. Selectors that cannot provide meaningful functionality simply do not match anything. Some of the supported selectors are:
 
 - `#!css .classes`
 - `#!css #ids`

--- a/docs/src/markdown/selectors.md
+++ b/docs/src/markdown/selectors.md
@@ -77,7 +77,9 @@ Selector                        | Example                             | Descript
 `:future`                       | `#!css p:future`                    | As the document is not rendered, this will never match.
 `:hover`                        | `#!css a:focus`                     | Focus states are not applicable, so this will never match.
 `:link`                         | `#!css a:link`                      | All links are treated as unvisited, so this will match every `#!html <a>` element with an `href` attribute.
+`:optional`                     | `#!css input:optional`              | Select every `#!html <input>` element without a `required` attribute.
 `:past`                         | `#!css p:past`                      | As the document is not rendered, this will never match.
+`:required`                     | `#!css input:required`              | Select every `#!html <input>` element with a `required` attribute.
 `:target`                       | `#!css #news:target`                | Elements cannot be targeted, so this will never match.
 `:visited`                      | `#!css a:visited`                   | All links are treated unvisited, so this will never match.
 

--- a/docs/src/markdown/selectors.md
+++ b/docs/src/markdown/selectors.md
@@ -44,6 +44,7 @@ Selector                        | Example                             | Descript
 `:first-of-type`                | `#!css p:first-of-type`             | Selects every `#!html <p>` element that is the first `#!html <p>` element of its parent.
 `:has(> sel, + sel)`            | `#!css :has(> div, + p)`            | Selects elements that have a direct child that is a `#!html <div>` or that have sibling of `#!html <p>` immediately following.
 `:is(sel, sel)`                 | `#!css :is(div, .some-class)`       | Selects elements that are not `#!html <div>` and do not have class `some-class`. The alias `:matches` is allowed as well. In CSS4 `:where` is like `:is` except specificity is always zero. Soup Sieve doesn't care about specificity, so `:where` is exactly like `:is`.
+`:lang(l1, l2)`                 | `#!css :lang('*-CH', en)`           | Select all elements with language `de-CH`, `it-CH`, `fr-CH`, and `rm-CH`. Will also match `en`, `en-US`, and `en-GB`. See CSS4 specification for more info.
 `:last-child`                   | `#!css p:last-child`                | Selects every `#!html <p>` element that is the last child of its parent.
 `:last-of-type`                 | `#!css p:last-of-type`              | Selects every `#!html <p>` element that is the last `#!html <p>` element of its parent.
 `:not(sel, sel)`                | `#!css :not(.some-class, #some-id)` | Selects elements that do not have class `some-class` and ID `some-id`.

--- a/docs/src/markdown/selectors.md
+++ b/docs/src/markdown/selectors.md
@@ -80,6 +80,7 @@ Selector                        | Example                             | Descript
 `:link`                         | `#!css a:link`                      | All links are treated as unvisited, so this will match every `#!html <a>` element with an `href` attribute.
 `:optional`                     | `#!css input:optional`              | Select every `#!html <input>` element without a `required` attribute.
 `:past`                         | `#!css p:past`                      | As the document is not rendered, this will never match.
+`:placeholder-shown`            | `#!css input:placeholder-shown`     | Selects every `#!html <input>` element that is showing a placeholder via the `placeholder` attribute.
 `:required`                     | `#!css input:required`              | Select every `#!html <input>` element with a `required` attribute.
 `:target`                       | `#!css #news:target`                | Elements cannot be targeted, so this will never match.
 `:visited`                      | `#!css a:visited`                   | All links are treated unvisited, so this will never match.

--- a/docs/src/markdown/selectors.md
+++ b/docs/src/markdown/selectors.md
@@ -65,6 +65,7 @@ Just because we include selectors from one source, does not mean we have intenti
 Selector                        | Example                             | Description
 ------------------------------- | ----------------------------------- | -----------
 `:contains(text)`               | `#!css p:contains(text)`            | Select all `#!html <p>` elements that contain "text" in their content, either directly in themselves or indirectly in their decedents.
+`[attribute!=value]`            | `#!css [target!=_blank]`            | Equivalent to `#!css :not([target=_blank])`.
 
 --8<--
 refs.txt

--- a/docs/src/markdown/selectors.md
+++ b/docs/src/markdown/selectors.md
@@ -69,11 +69,15 @@ Selector                        | Example                             | Descript
 `:active`                       | `#!css a:active`                    | Active states are not applicable, so this will never match.
 `:any-link`                     | `#!css a:any-link`                  | All links are treated as unvisited, so this will match every `#!html <a>` element with an `href` attribute.
 `:checked`                      | `#!css input:checked`               | Selects every checked `#!html <input>` element.
+`:current`                      | `#!css p:current`                   | As the document is not rendered, this will never match.
+`:current(sel, sel)`            | `#!css :current(p, li, dt, dd)`     | As the document is not rendered, this will never match.
 `:disabled`                     | `#!css input:disabled`              | Selects every disabled `#!html <input>` element.
 `:enabled`                      | `#!css input:enabled`               | Selects every enabled `#!html <input>` element.
 `:focus`                        | `#!css input:focus`                 | Focus states are not applicable, so this will never match.
+`:future`                       | `#!css p:future`                    | As the document is not rendered, this will never match.
 `:hover`                        | `#!css a:focus`                     | Focus states are not applicable, so this will never match.
 `:link`                         | `#!css a:link`                      | All links are treated as unvisited, so this will match every `#!html <a>` element with an `href` attribute.
+`:past`                         | `#!css p:past`                      | As the document is not rendered, this will never match.
 `:target`                       | `#!css #news:target`                | Elements cannot be targeted, so this will never match.
 `:visited`                      | `#!css a:visited`                   | All links are treated unvisited, so this will never match.
 

--- a/docs/src/markdown/selectors.md
+++ b/docs/src/markdown/selectors.md
@@ -71,6 +71,7 @@ Selector                        | Example                             | Descript
 `:checked`                      | `#!css input:checked`               | Selects every checked `#!html <input>` element.
 `:current`                      | `#!css p:current`                   | As the document is not rendered, this will never match.
 `:current(sel, sel)`            | `#!css :current(p, li, dt, dd)`     | As the document is not rendered, this will never match.
+`:default`                      | `#!css input:default`               | Selects all `#!html <inputs>` that are the default among their related elements. See CSS specification to learn more about all that this targets.
 `:disabled`                     | `#!css input:disabled`              | Selects every disabled `#!html <input>` element.
 `:enabled`                      | `#!css input:enabled`               | Selects every enabled `#!html <input>` element.
 `:focus`                        | `#!css input:focus`                 | Focus states are not applicable, so this will never match.

--- a/docs/src/markdown/selectors.md
+++ b/docs/src/markdown/selectors.md
@@ -4,7 +4,7 @@
 
 ### HTML and XML Selectors
 
-The CSS selectors are based on a limited subset of CSS4 selectors. Primarily support has been added for selectors that were feasible to implement and most likely to get practical use.
+The CSS selectors are based off of the CSS level 4 specification. Primarily support has been added for selectors that were feasible to implement and most likely to get practical use. Selectors that cannot provide meaningful matches, simply match nothing. An example would be `:focus` which will match nothing because elements cannot be focused outside of a browser. Though most of the selectors have been implemented, there are still a few that are not.
 
 Below shows accepted selectors. When speaking about namespaces, they only apply to XML, XHTML, or when dealing with recognized foreign tags in HTML5. You must configure the CSS [namespaces](./api.md#namespaces) when attempting to evaluate namespaces.
 

--- a/docs/src/markdown/selectors.md
+++ b/docs/src/markdown/selectors.md
@@ -2,6 +2,8 @@
 
 ## Level 1-4 Selectors
 
+### HTML and XML Selectors
+
 The CSS selectors are based on a limited subset of CSS4 selectors. Primarily support has been added for selectors that were feasible to implement and most likely to get practical use.
 
 Below shows accepted selectors. When speaking about namespaces, they only apply to XML, XHTML, or when dealing with recognized foreign tags in HTML5. You must configure the CSS [namespaces](./api.md#namespaces) when attempting to evaluate namespaces.
@@ -37,24 +39,43 @@ Selector                        | Example                             | Descript
 `[attribute*=value]`            | `#!css a[href*="sometext"]`         | Selects every `#!html <a>` element whose `href` attribute value contains the substring `sometext`.
 `[attribute=value i]`           | `#!css [title=flower i]`            | Selects any element with a `title` that equals `flower` regardless of case.
 `[attribute=value s]`           | `#!css [type=submit s]`             | Selects any element with a `type` that equals `submit`. Case sensitivity will be forced.
-`:not(sel, sel)`                | `#!css :not(.some-class, #some-id)` | Selects elements that do not have class `some-class` and ID `some-id`.
-`:is(sel, sel)`                 | `#!css :is(div, .some-class)`       | Selects elements that are not `#!html <div>` and do not have class `some-class`. The alias `:matches` is allowed as well. In CSS4 `:where` is like `:is` except specificity is always zero. Soup Sieve doesn't care about specificity, so `:where` is exactly like `:is`.
-`:has(> sel, + sel)`            | `#!css :has(> div, + p)`            | Selects elements that have a direct child that is a `#!html <div>` or that have sibling of `#!html <p>` immediately following.
+`:empty`                        | `#!css p:empty`                     | Selects every `#!html <p>` element that has no children and either no text. Whitespace and comments are ignored.
 `:first-child`                  | `#!css p:first-child`               | Selects every `#!html <p>` element that is the first child of its parent.
-`:last-child`                   | `#!css p:last-child`                | Selects every `#!html <p>` element that is the last child of its parent.
 `:first-of-type`                | `#!css p:first-of-type`             | Selects every `#!html <p>` element that is the first `#!html <p>` element of its parent.
+`:has(> sel, + sel)`            | `#!css :has(> div, + p)`            | Selects elements that have a direct child that is a `#!html <div>` or that have sibling of `#!html <p>` immediately following.
+`:is(sel, sel)`                 | `#!css :is(div, .some-class)`       | Selects elements that are not `#!html <div>` and do not have class `some-class`. The alias `:matches` is allowed as well. In CSS4 `:where` is like `:is` except specificity is always zero. Soup Sieve doesn't care about specificity, so `:where` is exactly like `:is`.
+`:last-child`                   | `#!css p:last-child`                | Selects every `#!html <p>` element that is the last child of its parent.
 `:last-of-type`                 | `#!css p:last-of-type`              | Selects every `#!html <p>` element that is the last `#!html <p>` element of its parent.
-`:only-child`                   | `#!css p:only-child`                | Selects every `#!html <p>` element that is the only child of its parent.
-`:only-of-type`                 | `#!css p:only-of-type`              | Selects every `#!html <p>` element that is the only `#!html <p>` element of its parent.
+`:not(sel, sel)`                | `#!css :not(.some-class, #some-id)` | Selects elements that do not have class `some-class` and ID `some-id`.
 `:nth-child(an+b [of S]?)`      | `#!css p:nth-child(2)`              | Selects every `#!html <p>` element that is the second child of its parent. Please see CSS specification for more info on format.
 `:nth-last-child(an+b [of S]?)` | `#!css p:nth-last-child(2)`         | Selects every `#!html <p>` element that is the second child of its parent, counting from the last child. Please see CSS specification for more info on format.
-`:nth-of-type(an+b)`            | `#!css p:nth-of-type(2)`            | Selects every `#!html <p>` element that is the second `#!html <p>` element of its parent. Please see CSS specification for more info on format.
 `:nth-last-of-type(an+b)`       | `#!css p:nth-last-of-type(2)`       | Selects every `#!html <p>` element that is the second `#!html <p>` element of its parent, counting from the last child. Please see CSS specification for more info on format.
+`:nth-of-type(an+b)`            | `#!css p:nth-of-type(2)`            | Selects every `#!html <p>` element that is the second `#!html <p>` element of its parent. Please see CSS specification for more info on format.
+`:only-child`                   | `#!css p:only-child`                | Selects every `#!html <p>` element that is the only child of its parent.
+`:only-of-type`                 | `#!css p:only-of-type`              | Selects every `#!html <p>` element that is the only `#!html <p>` element of its parent.
 `:root`                         | `#!css :root`                       | Selects the root element. In HTML, this is usually the `#!html <html>` element.
-`:empty`                        | `#!css p:empty`                     | Selects every `#!html <p>` element that has no children and either no text. Whitespace and comments are ignored.
 
 !!! warning "Experimental Selectors"
     `:has()` and `of S` support (in `:nth-child(an+b [of S]?)`) is experimental and may change. There are currently no reference implementations available in any browsers, not to mention the CSS4 specifications have not been finalized, so current implementation is based on our best interpretation. Any issues should be reported.
+
+### HTML Only Selectors
+
+There are a number of selectors that apply specifically to HTML documents. Such selectors will only match tags in HTML documents. Use of these selectors are not restricted from XML, but when used with XML documents, they will never match.
+
+Selectors that require states that only exist within a live HTML document, or are specifically tied to user interaction with a live document are allowed (if implemented), but will never match as well.
+
+Selector                        | Example                             | Description
+------------------------------- | ----------------------------------- | -----------
+`:active`                       | `#!css a:active`                    | Active states are not applicable, so this will never match.
+`:any-link`                     | `#!css a:any-link`                  | All links are treated as unvisited, so this will match every `#!html <a>` element with an `href` attribute.
+`:checked`                      | `#!css input:checked`               | Selects every checked `#!html <input>` element.
+`:disabled`                     | `#!css input:disabled`              | Selects every disabled `#!html <input>` element.
+`:enabled`                      | `#!css input:enabled`               | Selects every enabled `#!html <input>` element.
+`:focus`                        | `#!css input:focus`                 | Focus states are not applicable, so this will never match.
+`:hover`                        | `#!css a:focus`                     | Focus states are not applicable, so this will never match.
+`:link`                         | `#!css a:link`                      | All links are treated as unvisited, so this will match every `#!html <a>` element with an `href` attribute.
+`:target`                       | `#!css #news:target`                | Elements cannot be targeted, so this will never match.
+`:visited`                      | `#!css a:visited`                   | All links are treated unvisited, so this will never match.
 
 ## Custom Selectors
 
@@ -64,8 +85,8 @@ Just because we include selectors from one source, does not mean we have intenti
 
 Selector                        | Example                             | Description
 ------------------------------- | ----------------------------------- | -----------
-`:contains(text)`               | `#!css p:contains(text)`            | Select all `#!html <p>` elements that contain "text" in their content, either directly in themselves or indirectly in their decedents.
 `[attribute!=value]`            | `#!css [target!=_blank]`            | Equivalent to `#!css :not([target=_blank])`.
+`:contains(text)`               | `#!css p:contains(text)`            | Select all `#!html <p>` elements that contain "text" in their content, either directly in themselves or indirectly in their decedents.
 
 --8<--
 refs.txt

--- a/soupsieve/__meta__.py
+++ b/soupsieve/__meta__.py
@@ -186,5 +186,5 @@ def parse_version(ver, pre=False):
     return Version(major, minor, micro, release, pre, post, dev)
 
 
-__version_info__ = Version(1, 1, 0, ".dev")
+__version_info__ = Version(1, 1, 0, "final")
 __version__ = __version_info__._get_canonical()

--- a/soupsieve/__meta__.py
+++ b/soupsieve/__meta__.py
@@ -186,5 +186,5 @@ def parse_version(ver, pre=False):
     return Version(major, minor, micro, release, pre, post, dev)
 
 
-__version_info__ = Version(1, 0, 2, "final")
+__version_info__ = Version(1, 1, 0, ".dev")
 __version__ = __version_info__._get_canonical()

--- a/soupsieve/css_match.py
+++ b/soupsieve/css_match.py
@@ -421,37 +421,42 @@ class CSSMatch:
 
         match = False
         is_not = selectors.is_not
-        for selector in selectors:
-            match = is_not
-            # Verify tag matches
-            if not self.match_tag(el, selector.tag):
-                continue
-            # Verify `nth` matches
-            if not self.match_nth(el, selector.nth):
-                continue
-            if not self.match_empty(el, selector.empty):
-                continue
-            # Verify id matches
-            if selector.ids and not self.match_id(el, selector.ids):
-                continue
-            # Verify classes match
-            if selector.classes and not self.match_classes(el, selector.classes):
-                continue
-            # Verify attribute(s) match
-            if not self.match_attributes(el, selector.attributes):
-                continue
-            if selector.root and not self.match_root(el):
-                continue
-            # Verify pseudo selector patterns
-            if selector.selectors and not self.match_subselectors(el, selector.selectors):
-                continue
-            # Verify relationship selectors
-            if selector.relation and not self.match_relations(el, selector.relation):
-                continue
-            if not self.match_contains(el, selector.contains):
-                continue
-            match = not is_not
-            break
+        is_html = selectors.is_html
+        if not (is_html and self.is_xml):
+            for selector in selectors:
+                match = is_not
+                # We have a un-matchable situation (like `:focus` as you can focus an element in this environment)
+                if selector.no_match:
+                    continue
+                # Verify tag matches
+                if not self.match_tag(el, selector.tag):
+                    continue
+                # Verify `nth` matches
+                if not self.match_nth(el, selector.nth):
+                    continue
+                if not self.match_empty(el, selector.empty):
+                    continue
+                # Verify id matches
+                if selector.ids and not self.match_id(el, selector.ids):
+                    continue
+                # Verify classes match
+                if selector.classes and not self.match_classes(el, selector.classes):
+                    continue
+                # Verify attribute(s) match
+                if not self.match_attributes(el, selector.attributes):
+                    continue
+                if selector.root and not self.match_root(el):
+                    continue
+                # Verify pseudo selector patterns
+                if selector.selectors and not self.match_subselectors(el, selector.selectors):
+                    continue
+                # Verify relationship selectors
+                if selector.relation and not self.match_relations(el, selector.relation):
+                    continue
+                if not self.match_contains(el, selector.contains):
+                    continue
+                match = not is_not
+                break
 
         return match
 

--- a/soupsieve/css_match.py
+++ b/soupsieve/css_match.py
@@ -71,7 +71,11 @@ class CSSMatch:
                     p = ''
                     a = k
                 # Can't match a prefix attribute as we haven't specified one to match
+                # Try to match it normally as a whole `p:a` as selector may be trying `p\:a`.
                 if not prefix and p:
+                    if (attr == k if self.is_xml else util.lower(attr) == util.lower(k)):
+                        value = v
+                        break
                     continue
                 # We can't match our desired prefix attribute as the attribute doesn't have a prefix
                 if prefix and not p and prefix != '*':

--- a/soupsieve/css_match.py
+++ b/soupsieve/css_match.py
@@ -73,7 +73,7 @@ class CSSMatch:
                 # Can't match a prefix attribute as we haven't specified one to match
                 # Try to match it normally as a whole `p:a` as selector may be trying `p\:a`.
                 if not prefix and p:
-                    if (attr == k if self.is_xml else util.lower(attr) == util.lower(k)):
+                    if (self.is_xml and attr == k) or (not self.is_xml and util.lower(attr) == util.lower(k)):
                         value = v
                         break
                     continue
@@ -472,8 +472,6 @@ class CSSMatch:
 
         match = False
         name = el.attrs.get('name')
-        if not name:
-            return True
 
         def get_parent_form(el):
             """Find this input's form."""

--- a/soupsieve/css_parser.py
+++ b/soupsieve/css_parser.py
@@ -20,7 +20,9 @@ PSEUDO_SIMPLE = {
     ":only-of-type",
     ':checked',
     ':disabled',
-    ':enabled'
+    ':enabled',
+    ':required',
+    ':optional'
 }
 
 # Supported, simple pseudo classes that match nothing in the Soup Sieve environment
@@ -416,6 +418,30 @@ class CSSParser:
                                 fieldset[disabled] > :not(legend) *,
                                 fieldset[disabled] > *
                             ):not([disabled]))
+                            '''
+                        ),
+                        is_pseudo=True,
+                        html_only=True
+                    )
+                )
+            elif pseudo == ":required":
+                sel.selectors.append(
+                    self.parse_selectors(
+                        self.selector_iter(
+                            '''
+                            :is(input, textarea, select)[required])
+                            '''
+                        ),
+                        is_pseudo=True,
+                        html_only=True
+                    )
+                )
+            elif pseudo == ":optional":
+                sel.selectors.append(
+                    self.parse_selectors(
+                        self.selector_iter(
+                            '''
+                            :is(input, textarea, select):not([required]))
                             '''
                         ),
                         is_pseudo=True,

--- a/soupsieve/css_parser.py
+++ b/soupsieve/css_parser.py
@@ -280,7 +280,7 @@ class CSSParser:
         if dflags:
             util.warn_deprecated(
                 "The following flags are deprecated and may be repurposed in the future '0x%02X'" % dflags,
-                stacklevel=5
+                stacklevel=3
             )
 
     def parse_attribute_selector(self, sel, m, has_selector):

--- a/soupsieve/css_parser.py
+++ b/soupsieve/css_parser.py
@@ -279,7 +279,8 @@ class CSSParser:
         dflags = self.flags & util.DEPRECATED_FLAGS
         if dflags:
             util.warn_deprecated(
-                "The following flags are deprecated and may be repurposed in the future '0x%02X'" % dflags
+                "The following flags are deprecated and may be repurposed in the future '0x%02X'" % dflags,
+                stacklevel=5
             )
 
     def parse_attribute_selector(self, sel, m, has_selector):

--- a/soupsieve/css_types.py
+++ b/soupsieve/css_types.py
@@ -29,10 +29,14 @@ class Selector(util.Immutable):
 
     __slots__ = (
         'tag', 'ids', 'classes', 'attributes', 'nth', 'selectors',
-        'relation', 'rel_type', 'contains', 'empty', 'root', '_hash'
+        'relation', 'rel_type', 'contains', 'empty', 'root', 'no_match',
+        '_hash'
     )
 
-    def __init__(self, tag, ids, classes, attributes, nth, selectors, relation, rel_type, contains, empty, root):
+    def __init__(
+        self, tag, ids, classes, attributes, nth, selectors,
+        relation, rel_type, contains, empty, root, no_match
+    ):
         """Initialize."""
 
         super().__init__(
@@ -46,7 +50,8 @@ class Selector(util.Immutable):
             rel_type=rel_type,
             contains=contains,
             empty=empty,
-            root=root
+            root=root,
+            no_match=no_match
         )
 
 
@@ -101,14 +106,15 @@ class SelectorNth(util.Immutable):
 class SelectorList(util.Immutable):
     """Selector list."""
 
-    __slots__ = ("_selectors", "is_not", "_hash")
+    __slots__ = ("_selectors", "is_not", "is_html", "_hash")
 
-    def __init__(self, selectors=tuple(), is_not=False):
+    def __init__(self, selectors=tuple(), is_not=False, is_html=False):
         """Initialize."""
 
         super().__init__(
             _selectors=tuple(selectors),
-            is_not=is_not
+            is_not=is_not,
+            is_html=is_html
         )
 
     def __iter__(self):

--- a/soupsieve/css_types.py
+++ b/soupsieve/css_types.py
@@ -29,13 +29,15 @@ class Selector(util.Immutable):
 
     __slots__ = (
         'tag', 'ids', 'classes', 'attributes', 'nth', 'selectors',
-        'relation', 'rel_type', 'contains', 'empty', 'root', 'default', 'no_match',
+        'relation', 'rel_type', 'contains', 'empty', 'root', 'default', 'indeterminate',
+        'no_match',
         '_hash'
     )
 
     def __init__(
         self, tag, ids, classes, attributes, nth, selectors,
-        relation, rel_type, contains, empty, root, default, no_match
+        relation, rel_type, contains, empty, root, default, indeterminate,
+        no_match
     ):
         """Initialize."""
 
@@ -52,6 +54,7 @@ class Selector(util.Immutable):
             empty=empty,
             root=root,
             default=default,
+            indeterminate=indeterminate,
             no_match=no_match
         )
 

--- a/soupsieve/css_types.py
+++ b/soupsieve/css_types.py
@@ -29,14 +29,14 @@ class Selector(util.Immutable):
 
     __slots__ = (
         'tag', 'ids', 'classes', 'attributes', 'nth', 'selectors',
-        'relation', 'rel_type', 'contains', 'empty', 'root', 'default', 'indeterminate',
+        'relation', 'rel_type', 'contains', 'lang', 'empty', 'root', 'default', 'indeterminate',
         'no_match',
         '_hash'
     )
 
     def __init__(
         self, tag, ids, classes, attributes, nth, selectors,
-        relation, rel_type, contains, empty, root, default, indeterminate,
+        relation, rel_type, contains, lang, empty, root, default, indeterminate,
         no_match
     ):
         """Initialize."""
@@ -51,6 +51,7 @@ class Selector(util.Immutable):
             relation=relation,
             rel_type=rel_type,
             contains=contains,
+            lang=lang,
             empty=empty,
             root=root,
             default=default,
@@ -107,16 +108,44 @@ class SelectorNth(util.Immutable):
         )
 
 
+class SelectorLang(util.Immutable):
+    """Selector language rules."""
+
+    __slots__ = ("languages", "_hash",)
+
+    def __init__(self, languages):
+        """Initialize."""
+
+        super().__init__(
+            languages=tuple(languages)
+        )
+
+    def __iter__(self):
+        """Iterator."""
+
+        return iter(self.languages)
+
+    def __len__(self):  # pragma: no cover
+        """Length."""
+
+        return len(self.languages)
+
+    def __getitem__(self, index):  # pragma: no cover
+        """Get item."""
+
+        return self.languages[index]
+
+
 class SelectorList(util.Immutable):
     """Selector list."""
 
-    __slots__ = ("_selectors", "is_not", "is_html", "_hash")
+    __slots__ = ("selectors", "is_not", "is_html", "_hash")
 
     def __init__(self, selectors=tuple(), is_not=False, is_html=False):
         """Initialize."""
 
         super().__init__(
-            _selectors=tuple(selectors),
+            selectors=tuple(selectors),
             is_not=is_not,
             is_html=is_html
         )
@@ -124,17 +153,17 @@ class SelectorList(util.Immutable):
     def __iter__(self):
         """Iterator."""
 
-        return iter(self._selectors)
+        return iter(self.selectors)
 
     def __len__(self):
         """Length."""
 
-        return len(self._selectors)
+        return len(self.selectors)
 
     def __getitem__(self, index):
         """Get item."""
 
-        return self._selectors[index]
+        return self.selectors[index]
 
 
 def _pickle(p):
@@ -146,3 +175,4 @@ copyreg.pickle(SelectorTag, _pickle)
 copyreg.pickle(SelectorAttribute, _pickle)
 copyreg.pickle(SelectorNth, _pickle)
 copyreg.pickle(SelectorList, _pickle)
+copyreg.pickle(SelectorLang, _pickle)

--- a/soupsieve/css_types.py
+++ b/soupsieve/css_types.py
@@ -29,13 +29,13 @@ class Selector(util.Immutable):
 
     __slots__ = (
         'tag', 'ids', 'classes', 'attributes', 'nth', 'selectors',
-        'relation', 'rel_type', 'contains', 'empty', 'root', 'no_match',
+        'relation', 'rel_type', 'contains', 'empty', 'root', 'default', 'no_match',
         '_hash'
     )
 
     def __init__(
         self, tag, ids, classes, attributes, nth, selectors,
-        relation, rel_type, contains, empty, root, no_match
+        relation, rel_type, contains, empty, root, default, no_match
     ):
         """Initialize."""
 
@@ -51,6 +51,7 @@ class Selector(util.Immutable):
             contains=contains,
             empty=empty,
             root=root,
+            default=default,
             no_match=no_match
         )
 

--- a/tests/test_extra.py
+++ b/tests/test_extra.py
@@ -94,3 +94,43 @@ class TestLevel1(util.TestCase):
             ['1', '2'],
             flags=util.XML
         )
+
+    def test_attribute_not_equal(self):
+        """Test attribute with value that does not equal specified value."""
+
+        markup = """
+        <div id="div">
+        <p id="0">Some text <span id="1"> in a paragraph</span>.</p>
+        <a id="2" href="http://google.com">Link</a>
+        <span id="3">Direct child</span>
+        <pre id="pre">
+        <span id="4">Child 1</span>
+        <span id="5">Child 2</span>
+        <span id="6">Child 3</span>
+        </pre>
+        </div>
+        """
+
+        # No quotes
+        self.assert_selector(
+            markup,
+            'body [id!=\\35]',
+            ["div", "0", "1", "2", "3", "pre", "4", "6"],
+            flags=util.HTML5
+        )
+
+        # Quotes
+        self.assert_selector(
+            markup,
+            "body [id!='5']",
+            ["div", "0", "1", "2", "3", "pre", "4", "6"],
+            flags=util.HTML5
+        )
+
+        # Double quotes
+        self.assert_selector(
+            markup,
+            'body [id!="5"]',
+            ["div", "0", "1", "2", "3", "pre", "4", "6"],
+            flags=util.HTML5
+        )

--- a/tests/test_level1.py
+++ b/tests/test_level1.py
@@ -7,14 +7,12 @@ E F
 E, F
 .class
 #elementID
+:link
+:active
+:visited
 ```
 Not supported (with current opinions or plans the matter):
 
-- `:link`: visited or un-visited links have no meaning outside a browser, just search for `:is(a,area,link)[href]` to
-  target links. At most, the possibility of supporting the `:link` as an alias for `:link` may be considered in the
-  future as technically, all links are un-visited in our scenario.
-
-- `:active`: No elements in our environment can be "active", so this makes no sense in our context.
 """
 from . import util
 
@@ -162,4 +160,30 @@ class TestLevel1(util.TestCase):
             ".foo\\:bar\\3a foobar",
             ["1"],
             flags=util.HTML5
+        )
+
+    def test_link(self):
+        """Test link (all links are unvisited)."""
+
+        markup = """
+        <div>
+        <p>Some text <span id="1" class="foo:bar:foobar"> in a paragraph</span>.
+        <a id="2" class="bar" href="http://google.com">Link</a>
+        <a id="3">Placeholder text.</a>
+        </p>
+        </div>
+        """
+
+        self.assert_selector(
+            markup,
+            ":link",
+            ["2"],
+            flags=util.HTML5
+        )
+
+        self.assert_selector(
+            markup,
+            "a:link",
+            [],
+            flags=util.XML
         )

--- a/tests/test_level1.py
+++ b/tests/test_level1.py
@@ -187,3 +187,41 @@ class TestLevel1(util.TestCase):
             [],
             flags=util.XML
         )
+
+    def test_active(self):
+        """Test active."""
+
+        markup = """
+        <div>
+        <p>Some text <span id="1" class="foo:bar:foobar"> in a paragraph</span>.
+        <a id="2" class="bar" href="http://google.com">Link</a>
+        <a id="3">Placeholder text.</a>
+        </p>
+        </div>
+        """
+
+        self.assert_selector(
+            markup,
+            "a:active",
+            [],
+            flags=util.HTML5
+        )
+
+    def test_visited(self):
+        """Test visited."""
+
+        markup = """
+        <div>
+        <p>Some text <span id="1" class="foo:bar:foobar"> in a paragraph</span>.
+        <a id="2" class="bar" href="http://google.com">Link</a>
+        <a id="3">Placeholder text.</a>
+        </p>
+        </div>
+        """
+
+        self.assert_selector(
+            markup,
+            "a:visited",
+            [],
+            flags=util.HTML5
+        )

--- a/tests/test_level1.py
+++ b/tests/test_level1.py
@@ -11,8 +11,6 @@ E, F
 :active
 :visited
 ```
-Not supported (with current opinions or plans the matter):
-
 """
 from . import util
 

--- a/tests/test_level2.py
+++ b/tests/test_level2.py
@@ -14,11 +14,10 @@ E + F
 :focus
 ```
 
-Not supported (with current opinions or plans the matter):
+Not supported:
 
 - `:lang(en)`: In documents, `:lang()` can take into considerations information in `meta` and other things in the
-  header. At this point, there are no plans to implement this. If a reasonable proposal was introduced on how to
-  support this, it may be considered.
+  header.
 """
 from . import util
 

--- a/tests/test_level2.py
+++ b/tests/test_level2.py
@@ -10,6 +10,8 @@ E + F
 [foo='bar']
 [foo~='bar']
 [foo|='en']
+:hover
+:focus
 ```
 
 Not supported (with current opinions or plans the matter):
@@ -17,10 +19,6 @@ Not supported (with current opinions or plans the matter):
 - `:lang(en)`: In documents, `:lang()` can take into considerations information in `meta` and other things in the
   header. At this point, there are no plans to implement this. If a reasonable proposal was introduced on how to
   support this, it may be considered.
-
-- `:hover`: Items cannot be hovered in our environment, so this has little meaning and will not be implemented.
-
-- `:focus`: Items cannot be focused in our environment, so this has little meaning and will not be implemented.
 """
 from . import util
 

--- a/tests/test_level2.py
+++ b/tests/test_level2.py
@@ -363,3 +363,68 @@ class TestLevel2(util.TestCase):
             ["1", "4"],
             flags=util.HTML5
         )
+
+    def test_hover(self):
+        """Test hover."""
+
+        markup = """
+        <div>
+        <p>Some text <span id="1" class="foo:bar:foobar"> in a paragraph</span>.
+        <a id="2" class="bar" href="http://google.com">Link</a>
+        <a id="3">Placeholder text.</a>
+        </p>
+        </div>
+        """
+
+        self.assert_selector(
+            markup,
+            "a:hover",
+            [],
+            flags=util.HTML5
+        )
+
+    def test_focus(self):
+        """Test focus."""
+
+        markup = """
+        <form action="#">
+          <fieldset id='a' disabled>
+            <legend>
+              Simple fieldset <input type="radio" id="1" checked>
+              <fieldset id='b' disabled>
+                <legend>Simple fieldset <input type="radio" id="2" checked></legend>
+                <input type="radio" id="3" checked>
+                <label for="radio">radio</label>
+              </fieldset>
+            </legend>
+            <fieldset id='c' disabled>
+              <legend>Simple fieldset <input type="radio" id="4" checked></legend>
+              <input type="radio" id="5" checked>
+              <label for="radio">radio</label>
+            </fieldset>
+            <input type="radio" id="6" checked>
+            <label for="radio">radio</label>
+          </fieldset>
+          <optgroup id="opt-enable">
+            <option id="7" disabled>option</option>
+          </optgroup>
+          <optgroup id="8" disabled>
+            <option id="9">option</option>
+          </optgroup>
+          <a href="" id="link">text</a>
+        </form>
+        """
+
+        self.assert_selector(
+            markup,
+            "input:focus",
+            [],
+            flags=util.HTML5
+        )
+
+        self.assert_selector(
+            markup,
+            "input:not(:focus)",
+            ["1", "2", "3", "4", "5", "6"],
+            flags=util.HTML5
+        )

--- a/tests/test_level2.py
+++ b/tests/test_level2.py
@@ -12,12 +12,8 @@ E + F
 [foo|='en']
 :hover
 :focus
+:lang(en)
 ```
-
-Not supported:
-
-- `:lang(en)`: In documents, `:lang()` can take into considerations information in `meta` and other things in the
-  header.
 """
 from . import util
 
@@ -425,5 +421,34 @@ class TestLevel2(util.TestCase):
             markup,
             "input:not(:focus)",
             ["1", "2", "3", "4", "5", "6"],
+            flags=util.HTML5
+        )
+
+    def test_lang(self):
+        """Test language."""
+
+        markup = """
+        <div lang="de-DE">
+            <p id="1"></p>
+        </div>
+        <div lang="de-DE-1996">
+            <p id="2"></p>
+        </div>
+        <div lang="de-Latn-DE">
+            <p id="3"></p>
+        </div>
+        <div lang="de-Latf-DE">
+            <p id="4"></p>
+        </div>
+        <div lang="de-Latn-DE-1996">
+            <p id="5"></p>
+        </div>
+        <p id="6" lang="de-DE"></p>
+        """
+
+        self.assert_selector(
+            markup,
+            "p:lang(de)",
+            ['1', '2', '3', '4', '5', '6'],
             flags=util.HTML5
         )

--- a/tests/test_level3.py
+++ b/tests/test_level3.py
@@ -1011,3 +1011,29 @@ class TestLevel3(util.TestCase):
             ['1', '2', 'opt-enable', 'b', '3', 'link'],
             flags=util.HTML5
         )
+
+    def test_target(self):
+        """Test target."""
+
+        markup = """
+        <div>
+        <h2 id="head-1">Header 1</h1>
+        <div><p>content</p></div>
+        <h2 id="head-2">Header 2</h1>
+        <div><p>content</p></div>
+        </div>
+        """
+
+        self.assert_selector(
+            markup,
+            "#head-2:target",
+            [],
+            flags=util.HTML5
+        )
+
+        self.assert_selector(
+            markup,
+            "#head-2:not(:target)",
+            ["head-2"],
+            flags=util.HTML5
+        )

--- a/tests/test_level3.py
+++ b/tests/test_level3.py
@@ -438,6 +438,22 @@ class TestLevel3(util.TestCase):
 
         self.assert_selector(
             markup,
+            '[xlink\\:href*=forw],[xlink|href="images/sprites.svg#icon-redo"]',
+            ['1', '2'],
+            namespaces={"xlink": "http://www.w3.org/1999/xlink"},
+            flags=util.HTML5
+        )
+
+        self.assert_selector(
+            markup,
+            '[xlink\\:nomatch*=forw],[xlink|href="images/sprites.svg#icon-redo"]',
+            ['1'],
+            namespaces={"xlink": "http://www.w3.org/1999/xlink"},
+            flags=util.HTML5
+        )
+
+        self.assert_selector(
+            markup,
             '[bad|href*=forw]',
             [],
             namespaces={"xlink": "http://www.w3.org/1999/xlink"},

--- a/tests/test_level3.py
+++ b/tests/test_level3.py
@@ -24,9 +24,6 @@ E ~ F
 :enabled
 :disabled
 ```
-
-Not supported (with current opinions or plans the matter):
-
 """
 from . import util
 

--- a/tests/test_level3.py
+++ b/tests/test_level3.py
@@ -446,8 +446,8 @@ class TestLevel3(util.TestCase):
 
         self.assert_selector(
             markup,
-            '[xlink\\:nomatch*=forw],[xlink|href="images/sprites.svg#icon-redo"]',
-            ['1'],
+            '[xlink\\:nomatch*=forw]',
+            [],
             namespaces={"xlink": "http://www.w3.org/1999/xlink"},
             flags=util.HTML5
         )

--- a/tests/test_level3.py
+++ b/tests/test_level3.py
@@ -19,18 +19,14 @@ E ~ F
 :nth-last-child(an+b)
 :nth-of-type(an+b)
 :nth-of-last-type(an+b)
+:target
+:checked
+:enabled
+:disabled
 ```
 
 Not supported (with current opinions or plans the matter):
 
-- `:target`: Elements cannot be targeted in our environment, so this will not be implemented.
-
-- `:enabled` / `:disabled`: There are currently no plans to implement this.
-
-- `:checked`: Checked could be complicated to implement. Would you select the first item in a `<select>` tag if no
-  option is specified to be selected? Or would you consider this something that occurs when the document is live in the
-  browser?  There would need to be some considerations. What if a user has selected multiple radio boxes on accident?
-  Is this even useful in the context of how Soup Sieve would be used?
 """
 from . import util
 
@@ -822,5 +818,196 @@ class TestLevel3(util.TestCase):
             markup,
             "p:nth-last-of-type(2n + 1)",
             ['1', '8', '10'],
+            flags=util.HTML5
+        )
+
+    def test_checked(self):
+        """Test checked."""
+
+        markup = """
+        <div>
+          <input type="radio" name="my-input" id="yes" checked>
+          <label for="yes">Yes</label>
+
+          <input type="radio" name="my-input" id="no">
+          <label for="no">No</label>
+        </div>
+
+        <div>
+          <input type="checkbox" name="my-checkbox" id="opt-in" checked>
+          <label for="opt-in">Check me!</label>
+        </div>
+
+        <select name="my-select" id="fruit">
+          <option id="1" value="opt1">Apples</option>
+          <option id="2" value="opt2" selected>Grapes</option>
+          <option id="3" value="opt3">Pears</option>
+        </select>
+        """
+
+        self.assert_selector(
+            markup,
+            ":checked",
+            ['yes', 'opt-in', '2'],
+            flags=util.HTML5
+        )
+
+    def test_disabled(self):
+        """
+        Test disabled.
+
+        Form elements that have `disabled`.
+        `option` that is child of disabled `optgroup`.
+        Form elements that are children of a disabled `fieldset`, but not it's `legend`.
+        """
+
+        markup = """
+        <form action="#">
+          <fieldset id='a' disabled>
+            <legend>
+              Simple fieldset <input type="radio" id="1" checked>
+              <fieldset id='b' disabled>
+                <legend>Simple fieldset <input type="radio" id="2" checked></legend>
+                <input type="radio" id="3" checked>
+                <label for="radio">radio</label>
+              </fieldset>
+            </legend>
+            <fieldset id='c' disabled>
+              <legend>Simple fieldset <input type="radio" id="4" checked></legend>
+              <input type="radio" id="5" checked>
+              <label for="radio">radio</label>
+            </fieldset>
+            <input type="radio" id="6" checked>
+            <label for="radio">radio</label>
+          </fieldset>
+          <optgroup>
+            <option id="7" disabled>option</option>
+          </optgroup>
+          <optgroup id="8" disabled>
+            <option id="9">option</option>
+          </optgroup>
+        </form>
+        """
+
+        markup2 = """
+        <form action="#">
+          <fieldset id='a' disabled>
+            <legend>
+              Simple fieldset <input type="radio" id="1" checked>
+              <fieldset id='b'>
+                <legend>Simple fieldset <input type="radio" id="2" checked></legend>
+                <input type="radio" id="3" checked>
+                <label for="radio">radio</label>
+              </fieldset>
+            </legend>
+            <fieldset id='c' disabled>
+              <legend>Simple fieldset <input type="radio" id="4" checked></legend>
+              <input type="radio" id="5" checked>
+              <label for="radio">radio</label>
+            </fieldset>
+            <input type="radio" id="6" checked>
+            <label for="radio">radio</label>
+          </fieldset>
+          <optgroup>
+            <option id="7" disabled>option</option>
+          </optgroup>
+          <optgroup id="8" disabled>
+            <option id="9">option</option>
+          </optgroup>
+        </form>
+        """
+
+        self.assert_selector(
+            markup,
+            ":disabled",
+            ['3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c'],
+            flags=util.HTML5
+        )
+
+        self.assert_selector(
+            markup2,
+            ":disabled",
+            ['4', '5', '6', '7', '8', '9', 'a', 'c'],
+            flags=util.HTML5
+        )
+
+    def test_enable(self):
+        """
+        Test enable.
+
+        `:any-link`
+        Form elements that have `disabled`.
+        Form elements that are children of a disabled `fieldset`, but not it's `legend`.
+        """
+
+        markup = """
+        <form action="#">
+          <fieldset id='a' disabled>
+            <legend>
+              Simple fieldset <input type="radio" id="1" checked>
+              <fieldset id='b' disabled>
+                <legend>Simple fieldset <input type="radio" id="2" checked></legend>
+                <input type="radio" id="3" checked>
+                <label for="radio">radio</label>
+              </fieldset>
+            </legend>
+            <fieldset id='c' disabled>
+              <legend>Simple fieldset <input type="radio" id="4" checked></legend>
+              <input type="radio" id="5" checked>
+              <label for="radio">radio</label>
+            </fieldset>
+            <input type="radio" id="6" checked>
+            <label for="radio">radio</label>
+          </fieldset>
+          <optgroup id="opt-enable">
+            <option id="7" disabled>option</option>
+          </optgroup>
+          <optgroup id="8" disabled>
+            <option id="9">option</option>
+          </optgroup>
+          <a href="" id="link">text</a>
+        </form>
+        """
+
+        markup2 = """
+        <form action="#">
+          <fieldset id='a' disabled>
+            <legend>
+              Simple fieldset <input type="radio" id="1" checked>
+              <fieldset id='b'>
+                <legend>Simple fieldset <input type="radio" id="2" checked></legend>
+                <input type="radio" id="3" checked>
+                <label for="radio">radio</label>
+              </fieldset>
+            </legend>
+            <fieldset id='c' disabled>
+              <legend>Simple fieldset <input type="radio" id="4" checked></legend>
+              <input type="radio" id="5" checked>
+              <label for="radio">radio</label>
+            </fieldset>
+            <input type="radio" id="6" checked>
+            <label for="radio">radio</label>
+          </fieldset>
+          <optgroup id="opt-enable">
+            <option id="7" disabled>option</option>
+          </optgroup>
+          <optgroup id="8" disabled>
+            <option id="9">option</option>
+          </optgroup>
+          <a href="" id="link">text</a>
+        </form>
+        """
+
+        self.assert_selector(
+            markup,
+            ":enabled",
+            ['1', '2', 'opt-enable', 'link'],
+            flags=util.HTML5
+        )
+
+        self.assert_selector(
+            markup2,
+            ":enabled",
+            ['1', '2', 'opt-enable', 'b', '3', 'link'],
             flags=util.HTML5
         )

--- a/tests/test_level4.py
+++ b/tests/test_level4.py
@@ -40,8 +40,6 @@ Not supported:
 
 - `:read-only` / `:read-write`: There are no plans to implement this at this time.
 
-- `:required` / `:optional`: There are no plans to implement this at this time.
-
 - `:placeholder-shown`: There are no plans to implement this at this time.
 
 - `:indeterminate`: There are no plans to implement this at this time.
@@ -513,5 +511,63 @@ class TestLevel4(util.TestCase):
             markup,
             "p:future",
             [],
+            flags=util.HTML5
+        )
+
+    def test_required(self):
+        """Test required."""
+
+        markup = """
+        <form>
+        <input id="1" type="name" required>
+        <input id="2" type="checkbox" required>
+        <input id="3" type="email">
+        <textarea id="4" name="name" id="message" cols="30" rows="10" required></textarea>
+        <select id="5" name="nm" id="sel" required>
+            <!-- options -->
+        </select>
+        </form>
+        """
+
+        self.assert_selector(
+            markup,
+            ":required",
+            ['1', '2', '4', '5'],
+            flags=util.HTML5
+        )
+
+        self.assert_selector(
+            markup,
+            "input:required",
+            ['1', '2'],
+            flags=util.HTML5
+        )
+
+    def test_optional(self):
+        """Test optional."""
+
+        markup = """
+        <form>
+        <input id="1" type="name" required>
+        <input id="2" type="checkbox" required>
+        <input id="3" type="email">
+        <textarea id="4" name="name" id="message" cols="30" rows="10"></textarea>
+        <select id="5" name="nm" id="sel">
+            <!-- options -->
+        </select>
+        </form>
+        """
+
+        self.assert_selector(
+            markup,
+            ":optional",
+            ['3', '4', '5'],
+            flags=util.HTML5
+        )
+
+        self.assert_selector(
+            markup,
+            "input:optional",
+            ['3'],
             flags=util.HTML5
         )

--- a/tests/test_level4.py
+++ b/tests/test_level4.py
@@ -571,3 +571,93 @@ class TestLevel4(util.TestCase):
             ['3'],
             flags=util.HTML5
         )
+
+    def test_default(self):
+        """Test default."""
+
+        markup = """
+        <form>
+
+        <input type="radio" name="season" id="spring">
+        <label for="spring">Spring</label>
+
+        <input type="radio" name="season" id="summer" checked>
+        <label for="summer">Summer</label>
+
+        <input type="radio" name="season" id="fall">
+        <label for="fall">Fall</label>
+
+        <input type="radio" name="season" id="winter">
+        <label for="winter">Winter</label>
+
+        <select id="pet-select">
+            <option value="">--Please choose an option--</option>
+            <option id="dog" value="dog">Dog</option>
+            <option id="cat" value="cat">Cat</option>
+            <option id="hamster" value="hamster" selected>Hamster</option>
+            <option id="parrot" value="parrot">Parrot</option>
+            <option id="spider" value="spider">Spider</option>
+            <option id="goldfish" value="goldfish">Goldfish</option>
+        </select>
+
+        <input type="checkbox" name="enable" id="enable" checked>
+        <label for="enable">Enable</label>
+
+        <button type="button">
+        not default
+        </button>
+
+        <button id="d1" type="submit">
+        default1
+        </button>
+
+        <button id="d2" type="submit">
+        default2
+        </button>
+
+        </form>
+
+        <form>
+        <button id="d3" type="submit">
+        default3
+        </button>
+
+        <button id="d4" type="submit">
+        default4
+        </button>
+
+        </form>
+        """
+
+        self.assert_selector(
+            markup,
+            ":default",
+            ['summer', 'd1', 'd3', 'hamster', 'enable'],
+            flags=util.HTML5
+        )
+
+        # You shouldn't nest forms, but if you do,
+        # When we encounter a nested form, we will bail evaluation.
+        # We should see button 1 getting found for nested form, but button 2 will not be found
+        # for parent form.
+        markup2 = """
+        <form>
+
+        <form>
+        <button id="d1" type="submit">
+        button1
+        </button>
+        </form>
+
+        <button id="d2" type="submit">
+        button2
+        </button>
+        </form>
+        """
+
+        self.assert_selector(
+            markup2,
+            ":default",
+            ['d1'],
+            flags=util.HTML5
+        )

--- a/tests/test_level4.py
+++ b/tests/test_level4.py
@@ -17,6 +17,7 @@ Test selectors level 4.
 :target-within
 :default
 :indeterminate
+:placeholder-shown
 ```
 
 Not supported:
@@ -41,8 +42,6 @@ Not supported:
 - `:local-link`: In our environment, there is no document URL. This isn't currently practical.
 
 - `:read-only` / `:read-write`: There are no plans to implement this at this time.
-
-- `:placeholder-shown`: There are no plans to implement this at this time.
 
 - `:valid` / `:invalid`: We currently to not validate values, so this doesn't make sense at this time.
 
@@ -733,5 +732,49 @@ class TestLevel4(util.TestCase):
             markup,
             ":indeterminate",
             ['checkbox', 'radio1', 'radio6', 'radio4', 'radio5', 'radio-no-name1'],
+            flags=util.HTML5
+        )
+
+    def test_placeholder(self):
+        """Test placeholder shown."""
+
+        markup = """
+        <input id="0" placeholder="This is some text">
+        <textarea id="1" placeholder="This is some text"></textarea>
+
+        <input id="2" placeholder="">
+        <input id="3">
+
+        <input id="4" type="email" placeholder="This is some text">
+        <input id="5" type="number" placeholder="This is some text">
+        <input id="6" type="password" placeholder="This is some text">
+        <input id="7" type="search" placeholder="This is some text">
+        <input id="8" type="tel" placeholder="This is some text">
+        <input id="9" type="text" placeholder="This is some text">
+        <input id="10" type="url" placeholder="This is some text">
+        <input id="11" type="" placeholder="This is some text">
+        <input id="12" type placeholder="This is some text">
+
+        <input id="13" type="button" placeholder="This is some text">
+        <input id="14" type="checkbox" placeholder="This is some text">
+        <input id="15" type="color" placeholder="This is some text">
+        <input id="16" type="date" placeholder="This is some text">
+        <input id="17" type="datetime-local" placeholder="This is some text">
+        <input id="18" type="file" placeholder="This is some text">
+        <input id="19" type="hidden" placeholder="This is some text">
+        <input id="20" type="image" placeholder="This is some text">
+        <input id="21" type="month" placeholder="This is some text">
+        <input id="22" type="radio" placeholder="This is some text">
+        <input id="23" type="range" placeholder="This is some text">
+        <input id="24" type="reset" placeholder="This is some text">
+        <input id="25" type="submit" placeholder="This is some text">
+        <input id="26" type="time" placeholder="This is some text">
+        <input id="27" type="week" placeholder="This is some text">
+        """
+
+        self.assert_selector(
+            markup,
+            ":placeholder-shown",
+            ['0', '1', '4', '5', '6', '7', '8', '9', '10', '11', '12'],
             flags=util.HTML5
         )

--- a/tests/test_level4.py
+++ b/tests/test_level4.py
@@ -615,15 +615,22 @@ class TestLevel4(util.TestCase):
         </form>
 
         <form>
+
+        <div>
         <button id="d3" type="submit">
         default3
         </button>
+        </div>
 
         <button id="d4" type="submit">
         default4
         </button>
 
         </form>
+
+        <button id="d5" type="submit">
+        default4
+        </button>
         """
 
         self.assert_selector(
@@ -633,10 +640,7 @@ class TestLevel4(util.TestCase):
             flags=util.HTML5
         )
 
-        # You shouldn't nest forms, but if you do,
-        # When we encounter a nested form, we will bail evaluation.
-        # We should see button 1 getting found for nested form, but button 2 will not be found
-        # for parent form.
+        # This is technically invalid use of forms, but browsers will generally evaluated the nested form
         markup2 = """
         <form>
 
@@ -659,10 +663,38 @@ class TestLevel4(util.TestCase):
             flags=util.HTML5
         )
 
+        # You shouldn't nest forms, but if you do,
+        # When a parent form encounters a nested form, we will bail evaluation like browsers do.
+        # We should see button 1 getting found for nested form, but button 2 will not be found
+        # for parent form.
+        markup3 = """
+        <form>
+
+        <form>
+        <span>what</span>
+        </form>
+
+        <button id="d2" type="submit">
+        button2
+        </button>
+        </form>
+        """
+
+        self.assert_selector(
+            markup3,
+            ":default",
+            [],
+            flags=util.HTML5
+        )
+
     def test_indeterminate(self):
         """Test indeterminate."""
 
         markup = """
+        <input type="radio" name="" id="radio-no-name1">
+        <label>No name 1</label>
+        <input type="radio" name="" id="radio-no-name2" checked>
+        <label>no name 2</label>
         <div>
           <input type="checkbox" id="checkbox" indeterminate>
           <label for="checkbox">This label starts out lime.</label>
@@ -691,6 +723,6 @@ class TestLevel4(util.TestCase):
         self.assert_selector(
             markup,
             ":indeterminate",
-            ['checkbox', 'radio1', 'radio6', 'radio4', 'radio5'],
+            ['checkbox', 'radio1', 'radio6', 'radio4', 'radio5', 'radio-no-name1'],
             flags=util.HTML5
         )

--- a/tests/test_level4.py
+++ b/tests/test_level4.py
@@ -9,6 +9,14 @@ Test selectors level 4.
 :not(s1, s2, ...)
 :has(> s1, ...)
 :any-link
+:current
+:past
+:future
+:playing
+:paused
+:focus-within
+:focus-visible
+:target-within
 ```
 
 Likely to be implemented:
@@ -57,17 +65,10 @@ Not supported (with current opinions or plans the matter):
 - `:in-range` / `:out-of-range`: This applies to form elements only. You'd have to evaluate `value`, `min`, and `max`. I
   guess you can have numerical ranges and alphabetic ranges. Currently, there are no plans to implement this.
 
-- `:current` / `:past` / `:future`: I believe this requires a live, in browser state to determine what is current, to
-  then determine what is past and future. I don't think this is applicable to our environment.
-
 - `:default`: This is in the same vain as `:checked`. If we ever implemented that, we'd probably implement this, but
   there are no plans to do so at this time.
 
-- `:focus-within` / `:focus-visible`: There is no focus in our environment, so this will not be implemented.
-
 - `:target-within`: Elements cannot be "targeted" in our environment, so this will not be implemented.
-
-- `:playing` / `:paused`: Elements cannot be played or paused in our environment, so this will not be implemented.
 """
 from . import util
 import soupsieve as sv

--- a/tests/test_level4.py
+++ b/tests/test_level4.py
@@ -12,14 +12,12 @@ Test selectors level 4.
 :current
 :past
 :future
-:playing
-:paused
 :focus-within
 :focus-visible
 :target-within
 ```
 
-Likely to be implemented:
+Not supported:
 
 - `:nth-col(n)` / `:nth-last-col(n)`: This needs further understanding before implementing and would likely only be
   implemented for HTML, XHTML, and HTML5. This would not be implemented for XML.
@@ -27,23 +25,18 @@ Likely to be implemented:
 - `E || F`: This would need more understanding before implementation. This would likely only be implemented for HTML,
   XHTML, and HTML5. This would not be implemented for XML.
 
-Not supported (with current opinions or plans the matter):
-
-- `:blank`: This applies to inputs with empty or otherwise null input. Currently, there is no plans to implement this.
+- `:blank`: This applies to inputs with empty or otherwise null input.
 
 - `:dir(ltr)`: This applies to direction of text. This direction can be inherited from parents. Due to the way Soup
   Sieve process things, it would have to scan the parents and evaluate what is inherited. it doesn't account for the CSS
   `direction` value, which is a good thing. It is doable, but not sure worth the effort. In addition, it seems there is
   reference to being able to do something like `[dir=auto]` which would select either `ltr` or `rtl`. This seems to add
-  additional logic in to attribute selections which would complicate things, but still technically doable. There are
-  currently no plans to implement this.
+  additional logic in to attribute selections which would complicate things, but still technically doable.
 
 - `:lang(en-*)`: As mentioned in level 2 tests, in documents, `:lang()` can take into considerations information in
-  `meta` and other things in the header. At this point, there are no plans to implement this. If a reasonable proposal
-  was introduced on how to support this, it may be considered.
+  `meta` and other things in the header.
 
-- `:local-link`: In our environment, there is no document URL. This isn't currently practical. This will not be
-  implemented.
+- `:local-link`: In our environment, there is no document URL. This isn't currently practical.
 
 - `:read-only` / `:read-write`: There are no plans to implement this at this time.
 
@@ -68,7 +61,7 @@ Not supported (with current opinions or plans the matter):
 - `:default`: This is in the same vain as `:checked`. If we ever implemented that, we'd probably implement this, but
   there are no plans to do so at this time.
 
-- `:target-within`: Elements cannot be "targeted" in our environment, so this will not be implemented.
+- `:playing` / `:paused`: Elements cannot be played or paused in our environment, so this will not be implemented.
 """
 from . import util
 import soupsieve as sv
@@ -380,4 +373,145 @@ class TestLevel4(util.TestCase):
             ":not(a:any-link)",
             ["div", "0", "1", "2", "3"],
             flags=util.XML
+        )
+
+    def test_focus_within(self):
+        """Test focus within."""
+
+        markup = """
+        <form id="form">
+          <input type="text">
+        </form>
+        """
+
+        self.assert_selector(
+            markup,
+            "form:focus-within",
+            [],
+            flags=util.HTML5
+        )
+
+        self.assert_selector(
+            markup,
+            "form:not(:focus-within)",
+            ["form"],
+            flags=util.HTML5
+        )
+
+    def test_focus_visible(self):
+        """Test focus visible."""
+
+        markup = """
+        <form id="form">
+          <input type="text">
+        </form>
+        """
+
+        self.assert_selector(
+            markup,
+            "form:focus-visible",
+            [],
+            flags=util.HTML5
+        )
+
+        self.assert_selector(
+            markup,
+            "form:not(:focus-visible)",
+            ["form"],
+            flags=util.HTML5
+        )
+
+    def test_target_within(self):
+        """Test target within."""
+
+        markup = """
+        <a href="#head-2">Jump</a>
+        <article id="article">
+        <h2 id="head-1">Header 1</h1>
+        <div><p>content</p></div>
+        <h2 id="head-2">Header 2</h1>
+        <div><p>content</p></div>
+        </article>
+        """
+
+        self.assert_selector(
+            markup,
+            "article:target-within",
+            [],
+            flags=util.HTML5
+        )
+
+        self.assert_selector(
+            markup,
+            "article:not(:target-within)",
+            ["article"],
+            flags=util.HTML5
+        )
+
+    def test_current_past_future(self):
+        """Test current, past, future."""
+
+        markup = """
+        <div id="div">
+        <p id="0">Some text <span id="1" class="foo:bar:foobar"> in a paragraph</span>.
+        <a id="2" class="bar" href="http://google.com">Link</a>
+        <a id="3">Placeholder text.</a>
+        </p>
+        </div>
+        """
+
+        self.assert_selector(
+            markup,
+            ":current(p, div, a)",
+            [],
+            flags=util.HTML5
+        )
+
+        self.assert_selector(
+            markup,
+            ":current(p, :not(div), a)",
+            [],
+            flags=util.HTML5
+        )
+
+        self.assert_selector(
+            markup,
+            "body :not(:current(p, div, a))",
+            ["div", "0", "1", "2", "3"],
+            flags=util.HTML5
+        )
+
+        self.assert_selector(
+            markup,
+            "body :not(:current(p, :not(div), a))",
+            ["div", "0", "1", "2", "3"],
+            flags=util.HTML5
+        )
+
+        self.assert_selector(
+            markup,
+            "p:current",
+            [],
+            flags=util.HTML5
+        )
+
+        self.assert_selector(
+            markup,
+            "p:not(:current)",
+            ["0"],
+            flags=util.HTML5
+        )
+
+        self.assert_selector(
+            markup,
+            "p:past",
+            [],
+            flags=util.HTML5
+        )
+
+        self.assert_selector(
+            markup,
+            "p:future",
+            [],
+            flags=util.HTML5
         )

--- a/tests/test_level4.py
+++ b/tests/test_level4.py
@@ -8,6 +8,7 @@ Test selectors level 4.
 :where(s1, s2, ...) allowed, but due to our environment, works like `:is()`
 :not(s1, s2, ...)
 :has(> s1, ...)
+:any-link
 ```
 
 Likely to be implemented:
@@ -345,4 +346,37 @@ class TestLevel4(util.TestCase):
             ":nth-child(-n+3 of p)",
             ['0', '1', '7'],
             flags=util.HTML5
+        )
+
+    def test_anylink(self):
+        """Test any link (all links are unvisited)."""
+
+        markup = """
+        <div id="div">
+        <p id="0">Some text <span id="1" class="foo:bar:foobar"> in a paragraph</span>.
+        <a id="2" class="bar" href="http://google.com">Link</a>
+        <a id="3">Placeholder text.</a>
+        </p>
+        </div>
+        """
+
+        self.assert_selector(
+            markup,
+            ":any-link",
+            ["2"],
+            flags=util.HTML5
+        )
+
+        self.assert_selector(
+            markup,
+            "a:any-link",
+            [],
+            flags=util.XML
+        )
+
+        self.assert_selector(
+            markup,
+            ":not(a:any-link)",
+            ["div", "0", "1", "2", "3"],
+            flags=util.XML
         )

--- a/tests/test_level4.py
+++ b/tests/test_level4.py
@@ -663,6 +663,15 @@ class TestLevel4(util.TestCase):
             flags=util.HTML5
         )
 
+        # For the sake of coverage, we will do this impractical select
+        # to ensure we reuse the cached default.
+        self.assert_selector(
+            markup2,
+            ":default:default",
+            ['d1'],
+            flags=util.HTML5
+        )
+
         # You shouldn't nest forms, but if you do,
         # When a parent form encounters a nested form, we will bail evaluation like browsers do.
         # We should see button 1 getting found for nested form, but button 2 will not be found

--- a/tests/test_level4.py
+++ b/tests/test_level4.py
@@ -15,6 +15,8 @@ Test selectors level 4.
 :focus-within
 :focus-visible
 :target-within
+:default
+:indeterminate
 ```
 
 Not supported:
@@ -42,8 +44,6 @@ Not supported:
 
 - `:placeholder-shown`: There are no plans to implement this at this time.
 
-- `:indeterminate`: There are no plans to implement this at this time.
-
 - `:valid` / `:invalid`: We currently to not validate values, so this doesn't make sense at this time.
 
 - `:user-invalid`: User cannot alter things in our environment because there is no user interaction (we are not a
@@ -55,9 +55,6 @@ Not supported:
 
 - `:in-range` / `:out-of-range`: This applies to form elements only. You'd have to evaluate `value`, `min`, and `max`. I
   guess you can have numerical ranges and alphabetic ranges. Currently, there are no plans to implement this.
-
-- `:default`: This is in the same vain as `:checked`. If we ever implemented that, we'd probably implement this, but
-  there are no plans to do so at this time.
 
 - `:playing` / `:paused`: Elements cannot be played or paused in our environment, so this will not be implemented.
 """
@@ -659,5 +656,41 @@ class TestLevel4(util.TestCase):
             markup2,
             ":default",
             ['d1'],
+            flags=util.HTML5
+        )
+
+    def test_indeterminate(self):
+        """Test indeterminate."""
+
+        markup = """
+        <div>
+          <input type="checkbox" id="checkbox" indeterminate>
+          <label for="checkbox">This label starts out lime.</label>
+        </div>
+        <div>
+          <input type="radio" name="test" id="radio1">
+          <label for="radio">This label starts out lime.</label>
+          <form>
+            <input type="radio" name="test" id="radio2">
+            <label for="radio">This label starts out lime.</label>
+
+            <input type="radio" name="test" id="radio3" checked>
+            <label for="radio">This label starts out lime.</label>
+
+            <input type="radio" name="other" id="radio4">
+            <label for="radio">This label starts out lime.</label>
+
+            <input type="radio" name="other" id="radio5">
+            <label for="radio">This label starts out lime.</label>
+          </form>
+          <input type="radio" name="test" id="radio6">
+          <label for="radio">This label starts out lime.</label>
+        </div>
+        """
+
+        self.assert_selector(
+            markup,
+            ":indeterminate",
+            ['checkbox', 'radio1', 'radio6', 'radio4', 'radio5'],
             flags=util.HTML5
         )

--- a/tests/util.py
+++ b/tests/util.py
@@ -26,6 +26,6 @@ class TestCase(unittest.TestCase):
         soup = bs4.BeautifulSoup(textwrap.dedent(markup.replace('\r\n', '\n')), bs_mode)
 
         ids = []
-        for el in sv.select(selectors, soup, namespaces=namespaces, flags=flags):
+        for el in sv.select(selectors, soup, namespaces=namespaces):
             ids.append(el.attrs['id'])
         self.assertEqual(sorted(ids), sorted(expected_ids))


### PR DESCRIPTION
- Adds support for `[attr!=value]` which is equivalent to `:not([attr=value])`.
- Add support for `:active`, `:focus`, `:hover`, `:visited`, `:target`, `:focus-within`, `:focus-visible`, `:target-within`, `:current()`/`:current`, `:past`, and `:future`, but they will never match as these states don't exist in the Soup Sieve environment.
- Add support for `:checked`, `:enabled`, `:disabled`, `:required`, `:optional`, `:default`, and `:placeholder-shown` which will only match in HTML documents as these concepts are not defined in XML.
- Add support for `:link` and `:any-link`, both of which will target all `<a>`, `<area>`, and `<link>` elements with an `href` attribute as all links will be treated as unvisited in Soup Sieve.
- Add support for `:lang()` (CSS4) which works in XML and HTML.
- Attributes in the form `prefix:attr` can be matched with the form `[prefix\:attr]` without specifying a namespaces if desired.
- Fix exception when `[type]` is used (with no value).

Closes #18, Closes #17 