### PR TITLE
Add support for :scope

### DIFF
--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## 1.2.2
+## 1.3.0
 
+- **NEW**: Add support for `:scope`.
 - **FIX**: Fix `[attr~=value]` handling of whitespace. According to the spec, if the value contains whitespace, or is an empty string, it should not match anything.
 - **FIX**: Precompile internal patterns for pseudo-classes to prevent having to parse them again.
 

--- a/docs/src/markdown/api.md
+++ b/docs/src/markdown/api.md
@@ -23,7 +23,7 @@ Early in development, flags were used to specify document type, but as of 1.0.0,
 ## `soupsieve.select()`
 
 ```py3
-def select(select, parent, namespaces=None, limit=0, flags=0):
+def select(select, tag, namespaces=None, limit=0, flags=0):
     """Select the specified tags."""
 ```
 
@@ -84,7 +84,7 @@ def filter(select, nodes, namespaces=None, flags=0):
 ## `soupsieve.comments()`
 
 ```
-def comments(parent, limit=0, flags=0):
+def comments(tag, limit=0, flags=0):
     """Get comments only."""
 ```
 
@@ -120,16 +120,16 @@ class SoupSieve:
     def filter(self, iterable):
         """Filter."""
 
-    def comments(self, parent, limit=0):
+    def comments(self, tag, limit=0):
         """Get comments only."""
 
-    def icomments(self, parent, limit=0):
+    def icomments(self, tag, limit=0):
         """Iterate comments only."""
 
-    def select(self, parent, limit=0):
+    def select(self, tag, limit=0):
         """Select the specified tags."""
 
-    def iselect(self, parent, limit=0):
+    def iselect(self, tag, limit=0):
         """Iterate the specified tags."""
 ```
 

--- a/docs/src/markdown/selectors.md
+++ b/docs/src/markdown/selectors.md
@@ -55,6 +55,7 @@ Selector                        | Example                             | Descript
 `:only-child`                   | `#!css p:only-child`                | Selects every `#!html <p>` element that is the only child of its parent.
 `:only-of-type`                 | `#!css p:only-of-type`              | Selects every `#!html <p>` element that is the only `#!html <p>` element of its parent.
 `:root`                         | `#!css :root`                       | Selects the root element. In HTML, this is usually the `#!html <html>` element.
+`:scope`                        | `#!css :scope div`                  | Selects all `#!html <div>` elements under the current scope element. `:scope` is the element under match or select. In the case where a document (`BeautifulSoup` object, not a `Tag` object) is under select or match, `:scope` equals `:root`.
 
 !!! warning "Experimental Selectors"
     `:has()` and `of S` support (in `:nth-child(an+b [of S]?)`) is experimental and may change. There are currently no reference implementations available in any browsers, not to mention the CSS4 specifications have not been finalized, so current implementation is based on our best interpretation. Any issues should be reported.

--- a/soupsieve/__init__.py
+++ b/soupsieve/__init__.py
@@ -76,27 +76,27 @@ def filter(select, iterable, namespaces=None, flags=0):  # noqa: A001
     return compile(select, namespaces, flags).filter(iterable)
 
 
-def comments(parent, limit=0, flags=0):
+def comments(tag, limit=0, flags=0):
     """Get comments only."""
 
-    return compile("", None, flags).comments(parent, limit)
+    return compile("", None, flags).comments(tag, limit)
 
 
-def icomments(parent, limit=0, flags=0):
+def icomments(tag, limit=0, flags=0):
     """Iterate comments only."""
 
-    for tag in compile("", None, flags).icomments(parent, limit):
-        yield tag
+    for comment in compile("", None, flags).icomments(tag, limit):
+        yield comment
 
 
-def select(select, parent, namespaces=None, limit=0, flags=0):
+def select(select, tag, namespaces=None, limit=0, flags=0):
     """Select the specified tags."""
 
-    return compile(select, namespaces, flags).select(parent, limit)
+    return compile(select, namespaces, flags).select(tag, limit)
 
 
-def iselect(select, parent, namespaces=None, limit=0, flags=0):
+def iselect(select, tag, namespaces=None, limit=0, flags=0):
     """Iterate the specified tags."""
 
-    for tag in compile(select, namespaces, flags).iselect(parent, limit):
-        yield tag
+    for el in compile(select, namespaces, flags).iselect(tag, limit):
+        yield el

--- a/soupsieve/__meta__.py
+++ b/soupsieve/__meta__.py
@@ -186,5 +186,5 @@ def parse_version(ver, pre=False):
     return Version(major, minor, micro, release, pre, post, dev)
 
 
-__version_info__ = Version(1, 2, 2, ".dev")
+__version_info__ = Version(1, 3, 0, ".dev")
 __version__ = __version_info__._get_canonical()

--- a/soupsieve/css_parser.py
+++ b/soupsieve/css_parser.py
@@ -8,62 +8,63 @@ from collections import OrderedDict
 
 # Simple pseudo classes that take no parameters
 PSEUDO_SIMPLE = {
-    ":root",
-    ":empty",
-    ":link",
     ":any-link",
+    ":empty",
     ":first-child",
     ":first-of-type",
     ":last-child",
     ":last-of-type",
+    ":link",
     ":only-child",
     ":only-of-type",
+    ":root",
     ':checked',
+    ':default',
     ':disabled',
     ':enabled',
-    ':required',
-    ':optional',
-    ':default',
     ':indeterminate',
-    ':placeholder-shown'
+    ':optional',
+    ':placeholder-shown',
+    ':required',
+    ':scope'
 }
 
 # Supported, simple pseudo classes that match nothing in the Soup Sieve environment
 PSEUDO_SIMPLE_NO_MATCH = {
-    ":visited",
-    ':hover',
     ':active',
-    ':focus',
-    ':target',
     ':current',
-    ':past',
-    ':future',
-    ':focus-within',
+    ':focus',
     ':focus-visible',
-    ':target-within'
+    ':focus-within',
+    ':future',
+    ':hover',
+    ':past',
+    ':target',
+    ':target-within',
+    ':visited'
 }
 
 # Complex pseudo classes that take selector lists
 PSEUDO_COMPLEX = {
-    ":has",
-    ":contains",
-    ":is",
-    ":matches",
-    ":not",
-    ":where"
+    ':contains',
+    ':has',
+    ':is',
+    ':matches',
+    ':not',
+    ':where'
 }
 
 PSEUDO_COMPLEX_NO_MATCH = {
-    ":current"
+    ':current'
 }
 
 # Complex pseudo classes that take very specific parameters and are handled special
 PSEUDO_SPECIAL = {
-    ":nth-child",
-    ":nth-last-child",
-    ":nth-of-type",
-    ":nth-last-of-type",
-    ":lang"
+    ':lang',
+    ':nth-child',
+    ':nth-last-child',
+    ':nth-last-of-type',
+    ':nth-of-type'
 }
 
 PSEUDO_SUPPORTED = PSEUDO_SIMPLE | PSEUDO_SIMPLE_NO_MATCH | PSEUDO_COMPLEX | PSEUDO_COMPLEX_NO_MATCH | PSEUDO_SPECIAL
@@ -384,6 +385,8 @@ class CSSParser(object):
         elif not complex_pseudo and pseudo in PSEUDO_SIMPLE:
             if pseudo == ':root':
                 sel.flags |= ct.SEL_ROOT
+            elif pseudo == ':scope':
+                sel.flags |= ct.SEL_SCOPE
             elif pseudo == ':empty':
                 sel.flags |= ct.SEL_EMPTY
             elif pseudo in (':link', ':any-link'):

--- a/soupsieve/css_types.py
+++ b/soupsieve/css_types.py
@@ -10,6 +10,7 @@ SEL_EMPTY = 0x1
 SEL_ROOT = 0x2
 SEL_DEFAULT = 0x4
 SEL_INDETERMINATE = 0x8
+SEL_SCOPE = 0x10
 
 
 class Immutable(object):

--- a/tests/test_level4.py
+++ b/tests/test_level4.py
@@ -58,6 +58,8 @@ Not supported:
 from __future__ import unicode_literals
 from . import util
 import soupsieve as sv
+import textwrap
+import bs4
 
 
 class TestLevel4(util.TestCase):
@@ -1034,3 +1036,71 @@ class TestLevel4(util.TestCase):
             ['1', '3', '4', '5', '6'],
             flags=util.HTML5
         )
+
+    def test_scope(self):
+        """Test scope."""
+
+        markup = """
+        <html id="root">
+        <head>
+        </head>
+        <body>
+        <div id="div">
+        <p id="0" class="somewordshere">Some text <span id="1"> in a paragraph</span>.</p>
+        <a id="2" href="http://google.com">Link</a>
+        <span id="3" class="herewords">Direct child</span>
+        <pre id="pre" class="wordshere">
+        <span id="4">Child 1</span>
+        <span id="5">Child 2</span>
+        <span id="6">Child 3</span>
+        </pre>
+        </div>
+        </body>
+        </html>
+        """
+
+        # Scope is root when applied to a document node
+        self.assert_selector(
+            markup,
+            ":scope",
+            ["root"],
+            flags=util.HTML5
+        )
+
+        self.assert_selector(
+            markup,
+            ":scope > body > div",
+            ["div"],
+            flags=util.HTML5
+        )
+
+        soup = bs4.BeautifulSoup(textwrap.dedent(markup.replace('\r\n', '\n')), 'html5lib')
+        el = soup.html
+
+        # Scope is the element we are applying the select to, and that element is never returned
+        self.assertTrue(len(sv.select(':scope', el, flags=sv.DEBUG)) == 0)
+
+        # Scope here means the current element under select
+        ids = []
+        for el in sv.select(':scope div', el, flags=sv.DEBUG):
+            ids.append(el.attrs['id'])
+        self.assertEqual(sorted(ids), sorted(['div']))
+
+        el = soup.body
+        ids = []
+        for el in sv.select(':scope div', el, flags=sv.DEBUG):
+            ids.append(el.attrs['id'])
+        self.assertEqual(sorted(ids), sorted(['div']))
+
+        # `div` is the current element under select, and it has no `div` elements.
+        el = soup.div
+        ids = []
+        for el in sv.select(':scope div', el, flags=sv.DEBUG):
+            ids.append(el.attrs['id'])
+        self.assertEqual(sorted(ids), sorted([]))
+
+        # `div` does have an element with the class `.wordshere`
+        ids = []
+        for el in sv.select(':scope .wordshere', el, flags=sv.DEBUG):
+            ids.append(el.attrs['id'])
+        self.assertEqual(sorted(ids), sorted(['pre']))

--- a/tests/util.py
+++ b/tests/util.py
@@ -31,5 +31,6 @@ class TestCase(unittest.TestCase):
 
         ids = []
         for el in sv.select(selectors, soup, namespaces=namespaces, flags=sv.DEBUG):
+            print('TAG: ', el.name)
             ids.append(el.attrs['id'])
         self.assertEqual(sorted(ids), sorted(expected_ids))


### PR DESCRIPTION
Make CSSMatch take a "scope" for initialization purposes. Calculate
root and scope so that all match calls after will have references to the
current root and/or scope. Use the calculated root and scope variables
to match :root or :scope.