### PR TITLE
Add either failures or match nothing for certain unsupported selectors

### DIFF
--- a/docs/src/dictionary/en-custom.txt
+++ b/docs/src/dictionary/en-custom.txt
@@ -6,6 +6,7 @@ CDATA
 CSS
 CSS's
 Changelog
+DOM
 Hashable
 JQuery
 MERCHANTABILITY

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.4.0
+
+- **NEW**: Throw `NotImplementedError` for at-rules: `@page`, etc.
+- **NEW**: Match nothing for `:left`, `:right`, `:host`, `:host()`, and `:host-context()`.
+- **NEW**: Add support for `:read-write` and `:read-only`.
+
 ## 1.3.1
 
 - **FIX**: Fix issue with undefined namespaces.

--- a/docs/src/markdown/selectors.md
+++ b/docs/src/markdown/selectors.md
@@ -63,8 +63,10 @@ Selector                        | Example                             | Descript
 
     Some implementations are based from our interpretation of the specification. It is possible our interpretation is incorrect. This is more likely with selectors that currently have no reference implementations in browsers such as `:has()` and `of S` support in `:nth-child(an+b [of S]?)`. If any issues are discovered please report the issue with details and examples so we can get them right.
 
-!!! danger "Pseudo-elements"
+!!! danger "Not Implemented"
     Pseudo elements are not supported as they do not represent real elements.
+
+    At-rules (`@page`) are not supported.
 
 ### HTML Only Selectors
 
@@ -84,7 +86,11 @@ Selector                        | Example                             | Descript
 `:enabled`                      | `#!css input:enabled`               | Selects every enabled `#!html <input>` element.
 `:focus`                        | `#!css input:focus`                 | Focus states are not applicable, so this will never match.
 `:future`                       | `#!css p:future`                    | As the document is not rendered, this will never match.
+`:host`                         | `#!css :host`                       | Matches nothing as there is no Shadow DOM.
+`:host(sel, sel)`               | `#!css :host(h1)`                   | Matches nothing as there is no Shadow DOM.
+`:host-context(sel, sel)`       | `#!css :host-context(h1)`           | Matches nothing as there is no Shadow DOM.
 `:hover`                        | `#!css a:focus`                     | Focus states are not applicable, so this will never match.
+`:left`                         | `#!css @page :left`                 | Matches nothing as there is no print state.
 `:link`                         | `#!css a:link`                      | All links are treated as unvisited, so this will match every `#!html <a>` element with an `href` attribute.
 `:optional`                     | `#!css input:optional`              | Select every `#!html <input>` element without a `required` attribute.
 `:past`                         | `#!css p:past`                      | As the document is not rendered, this will never match.
@@ -94,6 +100,7 @@ Selector                        | Example                             | Descript
 `:read-only`                    | `#!css input:read-only`             | Selects every `#!html <input>` element that is not editable by the user.
 `:read-write`                   | `#!css input:read-write`            | Selects every `#!html <input>` element that is editable by the user. 
 `:required`                     | `#!css input:required`              | Select every `#!html <input>` element with a `required` attribute.
+`:right`                        | `#!css @page :right`                | Matches nothing as there is no print state.
 `:target`                       | `#!css #news:target`                | Elements cannot be targeted, so this will never match.
 `:user-invalid`                 | `#!css input:user-invalid`          | User interaction is not applicable, so this will never match.
 `:visited`                      | `#!css a:visited`                   | All links are treated unvisited, so this will never match.

--- a/soupsieve/__meta__.py
+++ b/soupsieve/__meta__.py
@@ -186,5 +186,5 @@ def parse_version(ver, pre=False):
     return Version(major, minor, micro, release, pre, post, dev)
 
 
-__version_info__ = Version(1, 3, 1, "final")
+__version_info__ = Version(1, 4, 0, ".dev")
 __version__ = __version_info__._get_canonical()

--- a/soupsieve/css_parser.py
+++ b/soupsieve/css_parser.py
@@ -39,11 +39,14 @@ PSEUDO_SIMPLE_NO_MATCH = {
     ':focus-visible',
     ':focus-within',
     ':future',
+    ':host',
     ':hover',
+    ':left',
     ':local-link',
     ':past',
     ':paused',
     ':playing',
+    ':right',
     ':target',
     ':target-within',
     ':user-invalid',
@@ -61,7 +64,9 @@ PSEUDO_COMPLEX = {
 }
 
 PSEUDO_COMPLEX_NO_MATCH = {
-    ':current'
+    ':current',
+    ':host',
+    ':host-context'
 }
 
 # Complex pseudo classes that take very specific parameters and are handled special
@@ -104,6 +109,8 @@ PAT_PSEUDO_CLASS = r':{ident}+(?:\({ws}*)?'.format(ws=WS, ident=IDENTIFIER)
 PAT_PSEUDO_CLOSE = r'{ws}*\)'.format(ws=WS)
 # Pseudo element (`::pseudo-element`)
 PAT_PSEUDO_ELEMENT = r':{}'.format(PAT_PSEUDO_CLASS)
+# At rule (`@page`, etc.) (not supported)
+PAT_AT_RULE = r'@P{ident}'.format(ident=IDENTIFIER)
 # Pseudo class `nth-child` (`:nth-child(an+b [of S]?)`, `:first-child`, etc.)
 PAT_PSEUDO_NTH_CHILD = r'''
 (?P<pseudo_nth_child>:nth-(?:last-)?child
@@ -274,6 +281,7 @@ class CSSParser(object):
             ("pseudo_lang", SelectorPattern(PAT_PSEUDO_LANG)),
             ("pseudo_class", SelectorPattern(PAT_PSEUDO_CLASS)),
             ("pseudo_element", SelectorPattern(PAT_PSEUDO_ELEMENT)),
+            ("at_rule", SelectorPattern(PAT_AT_RULE)),
             ("id", SelectorPattern(PAT_ID)),
             ("class", SelectorPattern(PAT_CLASS)),
             ("tag", SelectorPattern(PAT_TAG)),
@@ -660,7 +668,9 @@ class CSSParser(object):
                 key, m = next(iselector)
 
                 # Handle parts
-                if key == 'pseudo_class':
+                if key == "at_rule":
+                    raise NotImplementedError("At-rules found at position {}".format(m.start(0)))
+                elif key == 'pseudo_class':
                     has_selector = self.parse_pseudo_class(sel, m, has_selector, iselector)
                 elif key == 'pseudo_element':
                     raise NotImplementedError("Psuedo-element found at position {}".format(m.start(0)))

--- a/tests/test_level2.py
+++ b/tests/test_level2.py
@@ -13,11 +13,17 @@ E + F
 :hover
 :focus
 :lang(en)
+:left
+:right
+::pseudo-element (not implemented)
+@at-rule (not implemented)
 ```
 
 We will currently fail on pseudo-elements `::pseudo-element` as they are not real elements.
 At the time of CSS2, they were known as `:pseudo-element`. Soup Sieve will raise an error about
 an unknown pseudo-class when single `:` is used.
+
+We currently fail on at-rules `@at-rule` as they are not applicable in the Soup Sieve environment.
 """
 from __future__ import unicode_literals
 from . import util
@@ -487,3 +493,33 @@ class TestLevel2(util.TestCase):
 
         with self.assertRaises(NotImplementedError):
             sv.compile('::first-line')
+
+    def test_left(self):
+        """Test left (not supported)."""
+
+        markup = """<h1>header</h1><div><p>some text</p></div>"""
+
+        self.assert_selector(
+            markup,
+            ":left",
+            [],
+            flags=util.HTML5
+        )
+
+    def test_right(self):
+        """Test right (not supported)."""
+
+        markup = """<h1>header</h1><div><p>some text</p></div>"""
+
+        self.assert_selector(
+            markup,
+            ":right",
+            [],
+            flags=util.HTML5
+        )
+
+    def test_at_rule(self):
+        """Test at-rule (not supported)."""
+
+        with self.assertRaises(NotImplementedError):
+            sv.compile('@page :left')

--- a/tests/test_level4.py
+++ b/tests/test_level4.py
@@ -26,6 +26,9 @@ Test selectors level 4.
 :local-link
 :read-only
 :read-write
+:host
+:host(sel1, sel2, ...)
+:host-context(sel1, sel2, ...)
 ```
 
 Not supported:
@@ -1317,5 +1320,36 @@ class TestLevel4(util.TestCase):
                 '3', '13', '14', '15', '18', '19', '20', '22',
                 '23', '24', '25', '31', '32', '33'
             ],
+            flags=util.HTML5
+        )
+
+    def test_host(self):
+        """Test host (not supported)."""
+
+        markup = """<h1>header</h1><div><p>some text</p></div>"""
+
+        self.assert_selector(
+            markup,
+            ":host",
+            [],
+            flags=util.HTML5
+        )
+
+        self.assert_selector(
+            markup,
+            ":host(h1)",
+            [],
+            flags=util.HTML5
+        )
+
+    def test_host_context(self):
+        """Test host context (not supported)."""
+
+        markup = """<h1>header</h1><div><p>some text</p></div>"""
+
+        self.assert_selector(
+            markup,
+            ":host-context(h1, h2)",
+            [],
             flags=util.HTML5
         )


### PR DESCRIPTION
Fail for @at-rules
Match nothing for :host, :host(), :host-context, :left, and :right