### PR TITLE
Avoid a DeprecationWarning of collections module import

### DIFF
--- a/soupsieve/css_types.py
+++ b/soupsieve/css_types.py
@@ -1,6 +1,9 @@
 """CSS selector structure items."""
 from __future__ import unicode_literals
-from collections import Mapping
+try:
+    from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping
 from . import util
 
 __all__ = ('Selector', 'SelectorTag', 'SelectorAttribute', 'SelectorNth', 'SelectorList', 'Namespaces')


### PR DESCRIPTION
When I running some tests with Python 3.7.1, I got the following DeprecationWarning:

```
  /home/.../.eggs/soupsieve-1.6-py3.7.egg/soupsieve/css_types.py:3: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
    from collections import Mapping
```

This PR will fix the above warning.
