### PR TITLE
Fix issue that prevents using a leading combinator in :has() selector that is not the first selector

### DIFF
--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.7.1
+
+- **FIX**: Fix issue with `:has()` selector where a leading combinator can only be provided in the first selector in a
+  relative selector list.
+
 ## 1.7.0
 
 - **NEW**: Add support for `:in-range` and `:out-of-range` selectors. (#60)

--- a/soupsieve/__meta__.py
+++ b/soupsieve/__meta__.py
@@ -186,5 +186,5 @@ def parse_version(ver, pre=False):
     return Version(major, minor, micro, release, pre, post, dev)
 
 
-__version_info__ = Version(1, 7, 0, "final")
+__version_info__ = Version(1, 7, 1, "final")
 __version__ = __version_info__._get_canonical()

--- a/soupsieve/css_parser.py
+++ b/soupsieve/css_parser.py
@@ -738,8 +738,6 @@ class CSSParser(object):
                     else:
                         raise SyntaxError("Unmatched pseudo-class close at postion {}".format(m.start(0)))
                 elif key == 'combine':
-                    if split_last:
-                        raise SyntaxError("Unexpected combinator at position {}".format(m.start(0)))
                     if is_relative:
                         has_selector, sel, rel_type = self.parse_has_combinator(
                             sel, m, has_selector, selectors, rel_type, index

--- a/tests/test_level4.py
+++ b/tests/test_level4.py
@@ -286,6 +286,13 @@ class TestLevel4(util.TestCase):
 
         self.assert_selector(
             markup2,
+            'div:has(.ffff, > .bbbb, .jjjj)',
+            ['0', '4', '8'],
+            flags=util.HTML5
+        )
+
+        self.assert_selector(
+            markup2,
             'div:has(> :not(.bbbb, .ffff, .jjjj))',
             ['2', '6', '8'],
             flags=util.HTML5

--- a/tests/test_soupsieve.py
+++ b/tests/test_soupsieve.py
@@ -297,6 +297,12 @@ class TestInvalid(unittest.TestCase):
         with self.assertRaises(SyntaxError):
             sv.compile('div >')
 
+        with self.assertRaises(SyntaxError):
+            sv.compile('div, > a')
+
+        with self.assertRaises(SyntaxError):
+            sv.compile('div,, a')
+
     def test_invalid_pseudo(self):
         """Test invalid pseudo class."""
 
@@ -329,6 +335,18 @@ class TestInvalid(unittest.TestCase):
 
         with self.assertRaises(SyntaxError):
             sv.compile(':has()')
+
+        with self.assertRaises(SyntaxError):
+            sv.compile(':has(> has,, a)')
+
+        with self.assertRaises(SyntaxError):
+            sv.compile(':has(> has,, a)')
+
+        with self.assertRaises(SyntaxError):
+            sv.compile(':has(> has >)')
+
+        with self.assertRaises(SyntaxError):
+            sv.compile(':has(> has,)')
 
     def test_invalid_tag(self):
         """


### PR DESCRIPTION
Fix issue with `:has()` selector where a leading combinator can only be
provided in the first selector in a relative selector list.