### PR TITLE
Refactor of match

### DIFF
--- a/soupsieve/__init__.py
+++ b/soupsieve/__init__.py
@@ -92,7 +92,7 @@ def comments(tag, limit=0, flags=0):
 def icomments(tag, limit=0, flags=0):
     """Iterate comments only."""
 
-    for comment in cm.get_comments(tag, limit):
+    for comment in cm.CommentsMatch(tag).get_comments(limit):
         yield comment
 
 

--- a/soupsieve/util.py
+++ b/soupsieve/util.py
@@ -38,69 +38,6 @@ UC_A = ord('A')
 UC_Z = ord('Z')
 
 
-def is_doc(obj):
-    """Is `BeautifulSoup` object."""
-
-    import bs4
-    return isinstance(obj, bs4.BeautifulSoup)
-
-
-def is_tag(obj):
-    """Is tag."""
-
-    import bs4
-    return isinstance(obj, bs4.Tag)
-
-
-def is_comment(obj):
-    """Is comment."""
-
-    import bs4
-    return isinstance(obj, bs4.Comment)
-
-
-def is_declaration(obj):  # pragma: no cover
-    """Is declaration."""
-
-    import bs4
-    return isinstance(obj, bs4.Declaration)
-
-
-def is_cdata(obj):  # pragma: no cover
-    """Is CDATA."""
-
-    import bs4
-    return isinstance(obj, bs4.Declaration)
-
-
-def is_processing_instruction(obj):  # pragma: no cover
-    """Is processing instruction."""
-
-    import bs4
-    return isinstance(obj, bs4.ProcessingInstruction)
-
-
-def is_navigable_string(obj):
-    """Is navigable string."""
-
-    import bs4
-    return isinstance(obj, bs4.NavigableString)
-
-
-def is_special_string(obj):
-    """Is special string."""
-
-    import bs4
-    return isinstance(obj, (bs4.Comment, bs4.Declaration, bs4.CData, bs4.ProcessingInstruction))
-
-
-def get_navigable_string_type(obj):
-    """Get navigable string type."""
-
-    import bs4
-    return bs4.NavigableString
-
-
 def lower(string):
     """Lower."""
 


### PR DESCRIPTION
Refactor by splitting element related manipulation to its own mixin class. Also move input validation and parsing to its own mixin. Ensure we are calling the helper methods in the mixin.  This will help a few
areas where we are reusing the same logic over and over and ensure that we are consistent with our logic to prevent breakage in one off locations.

This may allow in the future the ability to derive some of the classes to perform CSS selects on something like etree (or other) objects directly if we feel the need in the future. There is no plan for this, but abstracting things like this will help with maintenance in the future.