### PR TITLE
Skip tests that require html5lib or lxml when not available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,10 @@ matrix:
     env: TOXENV=lint
   - python: 3.6
     env: TOXENV=documents
+  - python: 3.6
+    env: TOXENV=nolxml
+  - python: 3.6
+    env: TOXENV=nohtml5lib
   allow_failures:
   - python: 3.8-dev
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -13,6 +13,7 @@ import warnings
 class TestSoupSieve(util.TestCase):
     """Test Soup Sieve."""
 
+    @util.requires_html5lib
     def test_comments(self):
         """Test comments."""
 
@@ -37,6 +38,7 @@ class TestSoupSieve(util.TestCase):
         comments = [sv_util.ustr(c).strip() for c in sv.comments(soup)]
         self.assertEqual(sorted(comments), sorted(['before header', 'comment', "don't ignore"]))
 
+    @util.requires_html5lib
     def test_icomments(self):
         """Test comments iterator."""
 
@@ -61,6 +63,7 @@ class TestSoupSieve(util.TestCase):
         comments = [sv_util.ustr(c).strip() for c in sv.icomments(soup, limit=2)]
         self.assertEqual(sorted(comments), sorted(['before header', 'comment']))
 
+    @util.requires_html5lib
     def test_compiled_comments(self):
         """Test comments from compiled pattern."""
 
@@ -88,6 +91,7 @@ class TestSoupSieve(util.TestCase):
         comments = [sv_util.ustr(c).strip() for c in pattern.comments(soup)]
         self.assertEqual(sorted(comments), sorted(['before header', 'comment', "don't ignore"]))
 
+    @util.requires_html5lib
     def test_compiled_icomments(self):
         """Test comments iterator from compiled pattern."""
 
@@ -113,6 +117,7 @@ class TestSoupSieve(util.TestCase):
         comments = [sv_util.ustr(c).strip() for c in pattern.icomments(soup, limit=2)]
         self.assertEqual(sorted(comments), sorted(['before header', 'comment']))
 
+    @util.requires_html5lib
     def test_select(self):
         """Test select."""
 
@@ -140,6 +145,7 @@ class TestSoupSieve(util.TestCase):
 
         self.assertEqual(sorted(['5', 'some-id']), sorted(ids))
 
+    @util.requires_html5lib
     def test_select_limit(self):
         """Test select limit."""
 
@@ -168,6 +174,7 @@ class TestSoupSieve(util.TestCase):
 
         self.assertEqual(sorted(['5']), sorted(ids))
 
+    @util.requires_html5lib
     def test_select_one(self):
         """Test select one."""
 
@@ -194,6 +201,7 @@ class TestSoupSieve(util.TestCase):
             sv.select_one('span[id]', soup).attrs['id']
         )
 
+    @util.requires_html5lib
     def test_select_one_none(self):
         """Test select one returns none for no match."""
 
@@ -217,6 +225,7 @@ class TestSoupSieve(util.TestCase):
         soup = self.soup(markup, 'html5lib')
         self.assertEqual(None, sv.select_one('h1', soup))
 
+    @util.requires_html5lib
     def test_iselect(self):
         """Test select iterator."""
 
@@ -245,6 +254,7 @@ class TestSoupSieve(util.TestCase):
 
         self.assertEqual(sorted(['5', 'some-id']), sorted(ids))
 
+    @util.requires_html5lib
     def test_select_order(self):
         """Test select order."""
 
@@ -274,6 +284,7 @@ class TestSoupSieve(util.TestCase):
 
         self.assertEqual(sorted(['5']), sorted(ids))
 
+    @util.requires_html5lib
     def test_match(self):
         """Test matching."""
 
@@ -299,6 +310,7 @@ class TestSoupSieve(util.TestCase):
         self.assertTrue(sv.match('span#\\35', nodes[0]))
         self.assertFalse(sv.match('span#\\35', nodes[1]))
 
+    @util.requires_html5lib
     def test_filter_tag(self):
         """Test filter tag."""
 
@@ -324,6 +336,7 @@ class TestSoupSieve(util.TestCase):
         self.assertEqual(len(nodes), 1)
         self.assertEqual(nodes[0].attrs['id'], '6')
 
+    @util.requires_html5lib
     def test_filter_list(self):
         """
         Test filter list.
@@ -355,6 +368,7 @@ class TestSoupSieve(util.TestCase):
         self.assertEqual(len(nodes), 1)
         self.assertEqual(nodes[0].attrs['id'], '6')
 
+    @util.requires_html5lib
     def test_closest_match_parent(self):
         """Test match parent closest."""
 
@@ -374,6 +388,7 @@ class TestSoupSieve(util.TestCase):
         el = sv.select_one('#div-03', soup)
         self.assertTrue(sv.closest('#div-02', el).attrs['id'] == 'div-02')
 
+    @util.requires_html5lib
     def test_closest_match_complex_parent(self):
         """Test closest match complex parent."""
 
@@ -394,6 +409,7 @@ class TestSoupSieve(util.TestCase):
         self.assertTrue(sv.closest('article > div', el).attrs['id'] == 'div-01')
         self.assertTrue(sv.closest(':not(div)', el).attrs['id'] == 'article')
 
+    @util.requires_html5lib
     def test_closest_match_self(self):
         """Test closest match self."""
 
@@ -413,6 +429,7 @@ class TestSoupSieve(util.TestCase):
         el = sv.select_one('#div-03', soup)
         self.assertTrue(sv.closest('div div', el).attrs['id'] == 'div-03')
 
+    @util.requires_html5lib
     def test_closest_must_be_parent(self):
         """Test that closest only matches parents or self."""
 

--- a/tests/test_bs4_cases.py
+++ b/tests/test_bs4_cases.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 from bs4 import BeautifulSoup
 import unittest
 import soupsieve as sv
+from . import util
 
 
 class SelectorNthOfTypeBugTest(unittest.TestCase):
@@ -105,6 +106,7 @@ NAMESPACES = dict(x="http://www.w3.org/2003/05/soap-envelope",
                   z="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd")
 
 
+@util.requires_lxml
 def test_simple_xml():
     """Test basic XML."""
     xml = BeautifulSoup(SIMPLE_XML, "xml")
@@ -118,6 +120,7 @@ def test_simple_xml():
     assert not xml.select_one("header")
 
 
+@util.requires_lxml
 def test_namespace_xml():
     """Test namespace XML."""
     xml = BeautifulSoup(NAMESPACE_XML, "xml")
@@ -131,6 +134,7 @@ def test_namespace_xml():
     assert not xml.select_one("action")
 
 
+@util.requires_lxml
 def test_namespace_xml_with_namespace():
     """Test namespace selectors with XML."""
     xml = BeautifulSoup(NAMESPACE_XML, "xml")

--- a/tests/test_level2/test_child.py
+++ b/tests/test_level2/test_child.py
@@ -71,6 +71,7 @@ class TestChildQuirks(TestChild):
         self.purge()
         self.quirks = True
 
+    @util.requires_html5lib
     def test_leading_combinator_quirks(self):
         """Test scope with quirks."""
 

--- a/tests/test_level3/test_nth_child.py
+++ b/tests/test_level3/test_nth_child.py
@@ -198,7 +198,7 @@ class TestNthChild(util.TestCase):
         </body>
         """
 
-        for parser in ('html.parser', 'lxml', 'html5lib'):
+        for parser in util.available_parsers('html.parser', 'lxml', 'html5lib'):
             # Paragraph is the root. There is no document.
             markup = """<p id="1">text</p>"""
             soup = self.soup(markup, parser)

--- a/tests/test_level4/test_dir.py
+++ b/tests/test_level4/test_dir.py
@@ -134,7 +134,7 @@ class TestDir(util.TestCase):
 
         markup = """<input id="1" type="text" dir="auto">"""
         # Input is root
-        for parser in ('html.parser', 'lxml', 'html5lib'):
+        for parser in util.available_parsers('html.parser', 'lxml', 'html5lib'):
             soup = self.soup(markup, parser)
             fragment = soup.input.extract()
             self.assertTrue(sv.match(":root:dir(ltr)", fragment, flags=sv.DEBUG))

--- a/tests/test_level4/test_scope.py
+++ b/tests/test_level4/test_scope.py
@@ -47,7 +47,8 @@ class TestScope(util.TestCase):
     def test_scope_cannot_select_target(self):
         """Test that scope, the element which scope is called on, cannot be selected."""
 
-        for parser in ('html.parser', 'lxml', 'html5lib', 'xml'):
+        for parser in util.available_parsers(
+                'html.parser', 'lxml', 'html5lib', 'xml'):
             soup = self.soup(self.MARKUP, parser)
             el = soup.html
 
@@ -57,7 +58,8 @@ class TestScope(util.TestCase):
     def test_scope_is_select_target(self):
         """Test that scope is the element which scope is called on."""
 
-        for parser in ('html.parser', 'lxml', 'html5lib', 'xml'):
+        for parser in util.available_parsers(
+                'html.parser', 'lxml', 'html5lib', 'xml'):
             soup = self.soup(self.MARKUP, parser)
             el = soup.html
 

--- a/tests/util.py
+++ b/tests/util.py
@@ -8,13 +8,14 @@ import sys
 import pytest
 
 try:
-    from bs4.builder import HTML5TreeBuilder  # noqa
+    from bs4.builder import HTML5TreeBuilder  # noqa: F401
     HTML5LIB_PRESENT = True
 except ImportError:
     HTML5LIB_PRESENT = False
 
 try:
-    from bs4.builder import LXMLTreeBuilderForXML, LXMLTreeBuilder  # noqa
+    from bs4.builder import (  # noqa: F401
+        LXMLTreeBuilderForXML, LXMLTreeBuilder)
     LXML_PRESENT = True
 except ImportError:
     LXML_PRESENT = False

--- a/tests/util.py
+++ b/tests/util.py
@@ -5,6 +5,19 @@ import bs4
 import textwrap
 import soupsieve as sv
 import sys
+import pytest
+
+try:
+    from bs4.builder import HTML5TreeBuilder  # noqa
+    HTML5LIB_PRESENT = True
+except ImportError:
+    HTML5LIB_PRESENT = False
+
+try:
+    from bs4.builder import LXMLTreeBuilderForXML, LXMLTreeBuilder  # noqa
+    LXML_PRESENT = True
+except ImportError:
+    LXML_PRESENT = False
 
 PY3 = sys.version_info >= (3, 0)
 
@@ -99,6 +112,7 @@ class TestCase(unittest.TestCase):
             parsers = ('html5lib',)
         elif mode in (XHTML, XML):
             parsers = ('xml',)
+
         return parsers
 
     def assert_raises(self, pattern, exception, namespace=None):
@@ -116,7 +130,7 @@ class TestCase(unittest.TestCase):
         print('----Running Selector Test----')
         selector = self.compile_pattern(selectors, namespaces)
 
-        for parser in parsers:
+        for parser in available_parsers(*parsers):
             soup = self.soup(markup, parser)
             # print(soup)
 
@@ -125,3 +139,32 @@ class TestCase(unittest.TestCase):
                 print('TAG: ', el.name)
                 ids.append(el.attrs['id'])
             self.assertEqual(sorted(ids), sorted(expected_ids))
+
+
+def available_parsers(*parsers):
+    """Filter a list of parsers, down to the available ones.
+
+    If there are none, report the test as skipped to pytest.
+    """
+    ran_test = False
+    for parser in parsers:
+        if (parser in ('xml', 'lxml') and not LXML_PRESENT) or (
+                parser == 'html5lib' and not HTML5LIB_PRESENT):
+            print('SKIPPED {}, not installed'.format(parser))
+        else:
+            ran_test = True
+            yield parser
+    if not ran_test:
+        raise pytest.skip('no available parsers')
+
+
+def requires_lxml(test):
+    """Decorator that marks a test as requiring LXML."""
+    return pytest.mark.skipif(
+        not LXML_PRESENT, reason='test requires lxml')(test)
+
+
+def requires_html5lib(test):
+    """Decorator that marks a test as requiring html5lib."""
+    return pytest.mark.skipif(
+        not HTML5LIB_PRESENT, reason='test requires html5lib')(test)

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    {py27,py34,py35,py36,py37,py38}, lint, documents
+    {py27,py34,py35,py36,py37,py38}, lint, documents, nolxml, nohtml5lib
 
 [testenv]
 passenv = *
@@ -27,6 +27,22 @@ deps =
     -rrequirements/flake8.txt
 commands =
     flake8 {toxinidir}
+
+[testenv:nolxml]
+passenv = *
+deps =
+    -rrequirements/tests.txt
+commands =
+    pip uninstall -y lxml
+    py.test {toxinidir}
+
+[testenv:nohtml5lib]
+passenv = *
+deps =
+    -rrequirements/tests.txt
+commands =
+    pip uninstall -y html5lib
+    py.test {toxinidir}
 
 [flake8]
 exclude=build/*,.tox/*


### PR DESCRIPTION
html5lib and lxml are optional bs4 dependencies. If they are not available, test without them, skipping any tests that weren't able to be run.

In Debian, we package separate cPython 2.x and PyPy 2.x stacks. bs4 is available for PyPy in Debian, but html5lib and lxml aren't, yet. Let's just skip these tests when we can't run them, as bs4 does for its own tests.