### PR TITLE
Improve CSS syntax error reporting

### DIFF
--- a/docs/src/dictionary/en-custom.txt
+++ b/docs/src/dictionary/en-custom.txt
@@ -32,6 +32,7 @@ combinator
 combinators
 deprecations
 directionality
+formatter
 hashable
 html
 iterable
@@ -41,6 +42,7 @@ lxml
 matchable
 matcher
 matchers
+multiline
 namespace
 namespaces
 newline
@@ -52,6 +54,7 @@ pytest
 regex
 sublicense
 substring
+traceback
 tuple
 tuples
 un

--- a/soupsieve/css_parser.py
+++ b/soupsieve/css_parser.py
@@ -220,8 +220,9 @@ class SelectorSyntaxError(SyntaxError):
 
         super(SelectorSyntaxError, self).__init__(msg)
         self.text = pattern
-        self.lineno = 1
-        self.offset = index + 1 if index is not None else None
+        if pattern is not None and index is not None:
+            self.lineno = pattern.count('\n', 0, index) + 1
+            self.offset = index - pattern.rfind('\n', 0, index)
 
 
 class SelectorPattern(object):

--- a/soupsieve/css_parser.py
+++ b/soupsieve/css_parser.py
@@ -221,6 +221,10 @@ class SelectorSyntaxError(SyntaxError):
         super(SelectorSyntaxError, self).__init__(msg)
         self.text = pattern
         if pattern is not None and index is not None:
+            # The traceback formatter puts a ^ at the offset, but it assumes
+            # the text will be indented with four spaces.  It will indent the
+            # first line, but we have to adjust the other lines ourselves.
+            self.text = self.text.replace('\n', '\n    ')
             self.lineno = pattern.count('\n', 0, index) + 1
             self.offset = index - pattern.rfind('\n', 0, index)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -667,7 +667,7 @@ class TestSyntaxErrorReporting(util.TestCase):
                 'input\n'
                 '.field[type=42]')
         e = cm.exception
-        self.assertEqual(e.text, 'input\n.field[type=42]')
+        self.assertEqual(e.text, 'input\n    .field[type=42]')
         self.assertEqual(e.lineno, 2)
         self.assertEqual(e.offset, 7)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -644,3 +644,43 @@ class TestInvalidQuirks(TestInvalid):
             # Verify some things
             self.assertTrue(len(w) == 1)
             self.assertTrue(issubclass(w[-1].category, sv_util.QuirksWarning))
+
+
+class TestSyntaxErrorReporting(util.TestCase):
+    """Test reporting of syntax errors."""
+
+    def test_syntax_error_has_text_and_position(self):
+        """Test that selector syntax errors contain the position."""
+
+        with self.assertRaises(sv.cp.SelectorSyntaxError) as cm:
+            sv.compile('input.field[type=42]')
+        e = cm.exception
+        self.assertEqual(e.text, 'input.field[type=42]')
+        self.assertEqual(e.lineno, 1)
+        self.assertEqual(e.offset, 12)
+
+    def test_syntax_error_with_multiple_lines(self):
+        """Test that multiline selector errors have the right position."""
+
+        with self.assertRaises(sv.cp.SelectorSyntaxError) as cm:
+            sv.compile(
+                'input\n'
+                '.field[type=42]')
+        e = cm.exception
+        self.assertEqual(e.text, 'input\n.field[type=42]')
+        self.assertEqual(e.lineno, 2)
+        self.assertEqual(e.offset, 7)
+
+    def test_syntax_error_on_third_line(self):
+        """Test that multiline selector errors have the right position."""
+
+        with self.assertRaises(sv.cp.SelectorSyntaxError) as cm:
+            sv.compile(
+                'input:is(\n'
+                '  [name=foo]\n'
+                '  [type=42]\n'
+                ')\n'
+            )
+        e = cm.exception
+        self.assertEqual(e.lineno, 3)
+        self.assertEqual(e.offset, 3)


### PR DESCRIPTION
This produces tracebacks like the following:

    Traceback (most recent call last):
      ...
      File "/home/mg/src/zopefoundation/zc.catalog/.tox/py37/lib/python3.7/site-packages/zope/testbrowser/browser.py", line 1370, in getControlLabels
        forlbls = html.select('label[for=%s]' % controlid)
      File "/home/mg/src/zopefoundation/zc.catalog/.tox/py37/lib/python3.7/site-packages/bs4/element.py", line 1376, in select
        return soupsieve.select(selector, self, namespaces, limit, **kwargs)
      File "/home/mg/src/soupsieve/soupsieve/__init__.py", line 108, in select
        return compile(select, namespaces, flags).select(tag, limit)
      File "/home/mg/src/soupsieve/soupsieve/__init__.py", line 59, in compile
        return cp._cached_css_compile(pattern, namespaces, flags)
      File "/home/mg/src/soupsieve/soupsieve/css_parser.py", line 192, in _cached_css_compile
        CSSParser(pattern, flags).process_selectors(),
      File "/home/mg/src/soupsieve/soupsieve/css_parser.py", line 930, in process_selectors
        return self.parse_selectors(self.selector_iter(self.pattern), index, flags)
      File "/home/mg/src/soupsieve/soupsieve/css_parser.py", line 772, in parse_selectors
        key, m = next(iselector)
      File "/home/mg/src/soupsieve/soupsieve/css_parser.py", line 917, in selector_iter
        raise SelectorSyntaxError(msg, self.pattern)
      File "<string>", line 1
        label[for=BrowserAdd__zope.catalog.catalog.Catalog]
             ^
    soupsieve.css_parser.SelectorSyntaxError: Malformed attribute selector at position 5

whereas before the traceback ended in

      File "/home/mg/src/zopefoundation/zc.catalog/.tox/py37/lib/python3.7/site-packages/soupsieve/css_parser.py", line 881, in selector_iter
        raise SyntaxError(msg)
      File "<string>", line None
    SyntaxError: Malformed attribute selector at position 5

making it difficult to see what exactly was malformed about the selector.

I've also chosen to introduce an exception subclass (SelectorSyntaxError), so that CSS parse errors could be distinguished from genuine Python syntax errors.