### PR TITLE
@mgedmin better syntax errors

### DIFF
--- a/docs/src/dictionary/en-custom.txt
+++ b/docs/src/dictionary/en-custom.txt
@@ -32,6 +32,7 @@ combinator
 combinators
 deprecations
 directionality
+formatter
 hashable
 html
 iterable
@@ -41,6 +42,7 @@ lxml
 matchable
 matcher
 matchers
+multiline
 namespace
 namespaces
 newline
@@ -52,6 +54,7 @@ pytest
 regex
 sublicense
 substring
+traceback
 tuple
 tuples
 un

--- a/soupsieve/__init__.py
+++ b/soupsieve/__init__.py
@@ -30,12 +30,12 @@ from .__meta__ import __version__, __version_info__  # noqa: F401
 from . import css_parser as cp
 from . import css_match as cm
 from . import css_types as ct
-from .util import DEBUG, _QUIRKS  # noqa: F401
+from .util import DEBUG, _QUIRKS, SelectorSyntaxError  # noqa: F401
 
 __all__ = (
     'SoupSieve', 'compile', 'purge', 'DEBUG', "_QUIRKS"
     'comments', 'icomments', 'closest', 'select', 'select_one',
-    'iselect', 'match', 'filter'
+    'iselect', 'match', 'filter', 'SelectorSyntaxError'
 )
 
 SoupSieve = cm.SoupSieve

--- a/soupsieve/css_parser.py
+++ b/soupsieve/css_parser.py
@@ -5,6 +5,7 @@ from . import util
 from . import css_match as cm
 from . import css_types as ct
 from collections import OrderedDict
+from .util import SelectorSyntaxError
 
 # Simple pseudo classes that take no parameters
 PSEUDO_SIMPLE = {
@@ -210,23 +211,6 @@ def css_unescape(string):
         return util.uchr(int(m.group(1)[1:], 16)) if m.group(1) else m.group(2)[1:]
 
     return RE_CSS_ESC.sub(replace, string)
-
-
-class SelectorSyntaxError(SyntaxError):
-    """Syntax error in a CSS selector."""
-
-    def __init__(self, msg, pattern=None, index=None):
-        """Initialize."""
-
-        super(SelectorSyntaxError, self).__init__(msg)
-        self.text = pattern
-        if pattern is not None and index is not None:
-            # The traceback formatter puts a ^ at the offset, but it assumes
-            # the text will be indented with four spaces.  It will indent the
-            # first line, but we have to adjust the other lines ourselves.
-            self.text = self.text.replace('\n', '\n    ')
-            self.lineno = pattern.count('\n', 0, index) + 1
-            self.offset = index - pattern.rfind('\n', 0, index)
 
 
 class SelectorPattern(object):

--- a/soupsieve/util.py
+++ b/soupsieve/util.py
@@ -67,6 +67,27 @@ def uchr(i):
         return struct.pack('i', i).decode('utf-32')
 
 
+class SelectorSyntaxError(SyntaxError):
+    """Syntax error in a CSS selector."""
+
+    def __init__(self, msg, pattern, index):
+        """Initialize."""
+
+        self.line = pattern.count('\n', 0, index) + 1
+        self.col = index - pattern.rfind('\n', 0, index)
+        offset = 3
+        text = []
+        for n, line in enumerate(pattern.split('\n'), start=1):
+            text.append(('--> {}' if n == self.line else '    {}').format(line))
+            if self.line == n:
+                text.append((' ' * (self.col + offset)) + '^')
+        self.context = '\n'.join(text)
+
+        msg = '{}\n  line {}:\n{}'.format(msg, self.line, self.context)
+
+        super(SelectorSyntaxError, self).__init__(msg)
+
+
 def deprecated(message, stacklevel=2):  # pragma: no cover
     """
     Raise a `DeprecationWarning` when wrapped function/method is called.

--- a/soupsieve/util.py
+++ b/soupsieve/util.py
@@ -70,20 +70,30 @@ def uchr(i):
 class SelectorSyntaxError(SyntaxError):
     """Syntax error in a CSS selector."""
 
-    def __init__(self, msg, pattern, index):
+    def __init__(self, msg, pattern=None, index=None):
         """Initialize."""
 
-        self.line = pattern.count('\n', 0, index) + 1
-        self.col = index - pattern.rfind('\n', 0, index)
-        offset = 3
-        text = []
-        for n, line in enumerate(pattern.split('\n'), start=1):
-            text.append(('--> {}' if n == self.line else '    {}').format(line))
-            if self.line == n:
-                text.append((' ' * (self.col + offset)) + '^')
-        self.context = '\n'.join(text)
+        self.line = None
+        self.col = None
+        self.context = None
 
-        msg = '{}\n  line {}:\n{}'.format(msg, self.line, self.context)
+        if pattern is not None and index is not None:
+            self.line = pattern.count('\n', 0, index) + 1
+            self.col = index - pattern.rfind('\n', 0, index)
+            temp = pattern.split('\n')
+            multi = len(temp) > 1
+            offset = 3 if multi else -1
+            text = []
+            for n, line in enumerate(temp, start=1):
+                if multi:
+                    text.append(('--> {}' if n == self.line else '    {}').format(line))
+                else:
+                    text.append(line)
+                if self.line == n:
+                    text.append((' ' * (self.col + offset)) + '^')
+            self.context = '\n'.join(text)
+
+            msg = '{}\n  line {}:\n{}'.format(msg, self.line, self.context)
 
         super(SelectorSyntaxError, self).__init__(msg)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -655,9 +655,9 @@ class TestSyntaxErrorReporting(util.TestCase):
         with self.assertRaises(sv.cp.SelectorSyntaxError) as cm:
             sv.compile('input.field[type=42]')
         e = cm.exception
-        self.assertEqual(e.text, 'input.field[type=42]')
-        self.assertEqual(e.lineno, 1)
-        self.assertEqual(e.offset, 12)
+        self.assertEqual(e.context, '--> input.field[type=42]\n               ^')
+        self.assertEqual(e.line, 1)
+        self.assertEqual(e.col, 12)
 
     def test_syntax_error_with_multiple_lines(self):
         """Test that multiline selector errors have the right position."""
@@ -667,9 +667,9 @@ class TestSyntaxErrorReporting(util.TestCase):
                 'input\n'
                 '.field[type=42]')
         e = cm.exception
-        self.assertEqual(e.text, 'input\n    .field[type=42]')
-        self.assertEqual(e.lineno, 2)
-        self.assertEqual(e.offset, 7)
+        self.assertEqual(e.context, '    input\n--> .field[type=42]\n          ^')
+        self.assertEqual(e.line, 2)
+        self.assertEqual(e.col, 7)
 
     def test_syntax_error_on_third_line(self):
         """Test that multiline selector errors have the right position."""
@@ -682,5 +682,5 @@ class TestSyntaxErrorReporting(util.TestCase):
                 ')\n'
             )
         e = cm.exception
-        self.assertEqual(e.lineno, 3)
-        self.assertEqual(e.offset, 3)
+        self.assertEqual(e.line, 3)
+        self.assertEqual(e.col, 3)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -652,17 +652,17 @@ class TestSyntaxErrorReporting(util.TestCase):
     def test_syntax_error_has_text_and_position(self):
         """Test that selector syntax errors contain the position."""
 
-        with self.assertRaises(sv.cp.SelectorSyntaxError) as cm:
+        with self.assertRaises(sv.SelectorSyntaxError) as cm:
             sv.compile('input.field[type=42]')
         e = cm.exception
-        self.assertEqual(e.context, '--> input.field[type=42]\n               ^')
+        self.assertEqual(e.context, 'input.field[type=42]\n           ^')
         self.assertEqual(e.line, 1)
         self.assertEqual(e.col, 12)
 
     def test_syntax_error_with_multiple_lines(self):
         """Test that multiline selector errors have the right position."""
 
-        with self.assertRaises(sv.cp.SelectorSyntaxError) as cm:
+        with self.assertRaises(sv.SelectorSyntaxError) as cm:
             sv.compile(
                 'input\n'
                 '.field[type=42]')
@@ -674,7 +674,7 @@ class TestSyntaxErrorReporting(util.TestCase):
     def test_syntax_error_on_third_line(self):
         """Test that multiline selector errors have the right position."""
 
-        with self.assertRaises(sv.cp.SelectorSyntaxError) as cm:
+        with self.assertRaises(sv.SelectorSyntaxError) as cm:
             sv.compile(
                 'input:is(\n'
                 '  [name=foo]\n'
@@ -684,3 +684,15 @@ class TestSyntaxErrorReporting(util.TestCase):
         e = cm.exception
         self.assertEqual(e.line, 3)
         self.assertEqual(e.col, 3)
+
+    def test_simple_syntax_error(self):
+        """Test a simple syntax error (no context)."""
+
+        with self.assertRaises(sv.SelectorSyntaxError) as cm:
+            raise sv.SelectorSyntaxError('Syntax Message')
+
+        e = cm.exception
+        self.assertEqual(e.context, None)
+        self.assertEqual(e.line, None)
+        self.assertEqual(e.col, None)
+        self.assertEqual(str(e), 'Syntax Message')

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -644,3 +644,43 @@ class TestInvalidQuirks(TestInvalid):
             # Verify some things
             self.assertTrue(len(w) == 1)
             self.assertTrue(issubclass(w[-1].category, sv_util.QuirksWarning))
+
+
+class TestSyntaxErrorReporting(util.TestCase):
+    """Test reporting of syntax errors."""
+
+    def test_syntax_error_has_text_and_position(self):
+        """Test that selector syntax errors contain the position."""
+
+        with self.assertRaises(sv.cp.SelectorSyntaxError) as cm:
+            sv.compile('input.field[type=42]')
+        e = cm.exception
+        self.assertEqual(e.text, 'input.field[type=42]')
+        self.assertEqual(e.lineno, 1)
+        self.assertEqual(e.offset, 12)
+
+    def test_syntax_error_with_multiple_lines(self):
+        """Test that multiline selector errors have the right position."""
+
+        with self.assertRaises(sv.cp.SelectorSyntaxError) as cm:
+            sv.compile(
+                'input\n'
+                '.field[type=42]')
+        e = cm.exception
+        self.assertEqual(e.text, 'input\n    .field[type=42]')
+        self.assertEqual(e.lineno, 2)
+        self.assertEqual(e.offset, 7)
+
+    def test_syntax_error_on_third_line(self):
+        """Test that multiline selector errors have the right position."""
+
+        with self.assertRaises(sv.cp.SelectorSyntaxError) as cm:
+            sv.compile(
+                'input:is(\n'
+                '  [name=foo]\n'
+                '  [type=42]\n'
+                ')\n'
+            )
+        e = cm.exception
+        self.assertEqual(e.lineno, 3)
+        self.assertEqual(e.offset, 3)

--- a/tests/test_level1/test_class.py
+++ b/tests/test_level1/test_class.py
@@ -1,6 +1,7 @@
 """Test class selectors."""
 from __future__ import unicode_literals
 from .. import util
+from soupsieve import SelectorSyntaxError
 
 
 class TestClass(util.TestCase):
@@ -38,7 +39,7 @@ class TestClass(util.TestCase):
         """Test malformed class."""
 
         # Malformed class
-        self.assert_raises('td.+#some-id', SyntaxError)
+        self.assert_raises('td.+#some-id', SelectorSyntaxError)
 
     def test_class_xhtml(self):
         """Test tag and class with XHTML since internally classes are stored different for XML."""
@@ -74,7 +75,7 @@ class TestClass(util.TestCase):
         """Test malformed class."""
 
         # Malformed pseudo-class
-        self.assert_raises('td:#id', SyntaxError)
+        self.assert_raises('td:#id', SelectorSyntaxError)
 
 
 class TestClassQuirks(TestClass):

--- a/tests/test_level1/test_id.py
+++ b/tests/test_level1/test_id.py
@@ -1,6 +1,7 @@
 """Test ID selectors."""
 from __future__ import unicode_literals
 from .. import util
+from soupsieve import SelectorSyntaxError
 
 
 class TestId(util.TestCase):
@@ -38,7 +39,7 @@ class TestId(util.TestCase):
         """Test malformed ID."""
 
         # Malformed id
-        self.assert_raises('td#.some-class', SyntaxError)
+        self.assert_raises('td#.some-class', SelectorSyntaxError)
 
 
 class TestIdQuirks(TestId):

--- a/tests/test_level1/test_list.py
+++ b/tests/test_level1/test_list.py
@@ -1,6 +1,7 @@
 """Test selector lists."""
 from __future__ import unicode_literals
 from .. import util
+from soupsieve import SelectorSyntaxError
 
 
 class TestSelectorLists(util.TestCase):
@@ -25,17 +26,17 @@ class TestSelectorLists(util.TestCase):
     def test_invalid_start_comma(self):
         """Test that selectors cannot start with a comma."""
 
-        self.assert_raises(', p', SyntaxError)
+        self.assert_raises(', p', SelectorSyntaxError)
 
     def test_invalid_end_comma(self):
         """Test that selectors cannot end with a comma."""
 
-        self.assert_raises('p,', SyntaxError)
+        self.assert_raises('p,', SelectorSyntaxError)
 
     def test_invalid_double_comma(self):
         """Test that selectors cannot have double combinators."""
 
-        self.assert_raises('div,, a', SyntaxError)
+        self.assert_raises('div,, a', SelectorSyntaxError)
 
 
 class TestSelectorListsQuirks(TestSelectorLists):

--- a/tests/test_level1/test_type.py
+++ b/tests/test_level1/test_type.py
@@ -1,6 +1,7 @@
 """Test type selectors."""
 from __future__ import unicode_literals
 from .. import util
+from soupsieve import SelectorSyntaxError
 
 
 class TestType(util.TestCase):
@@ -103,7 +104,7 @@ class TestType(util.TestCase):
     def test_invalid_syntax(self):
         """Test invalid syntax."""
 
-        self.assert_raises('div?', SyntaxError)
+        self.assert_raises('div?', SelectorSyntaxError)
 
 
 class TestTypeQuirks(TestType):

--- a/tests/test_level2/test_attribute.py
+++ b/tests/test_level2/test_attribute.py
@@ -1,6 +1,7 @@
 """Test attribute selector."""
 from __future__ import unicode_literals
 from .. import util
+from soupsieve import SelectorSyntaxError
 
 
 class TestAttribute(util.TestCase):
@@ -146,14 +147,14 @@ class TestAttribute(util.TestCase):
         Tag must come first.
         """
 
-        self.assert_raises('[href]p', SyntaxError)
+        self.assert_raises('[href]p', SelectorSyntaxError)
 
     @util.skip_quirks
     def test_malformed_no_quirk(self):
         """Test malformed with no quirk mode."""
 
         # Malformed attribute
-        self.assert_raises('div[attr={}]', SyntaxError)
+        self.assert_raises('div[attr={}]', SelectorSyntaxError)
 
     def test_attribute_type_html(self):
         """Type is treated as case insensitive in HTML."""

--- a/tests/test_level2/test_child.py
+++ b/tests/test_level2/test_child.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 from .. import util
 import soupsieve as sv
+from soupsieve import SelectorSyntaxError
 
 
 class TestChild(util.TestCase):
@@ -45,21 +46,21 @@ class TestChild(util.TestCase):
     def test_invalid_double_combinator(self):
         """Test that selectors cannot have double combinators."""
 
-        self.assert_raises('div >> p', SyntaxError)
-        self.assert_raises('>> div > p', SyntaxError)
+        self.assert_raises('div >> p', SelectorSyntaxError)
+        self.assert_raises('>> div > p', SelectorSyntaxError)
 
     def test_invalid_trailing_combinator(self):
         """Test that selectors cannot have a trailing combinator."""
 
-        self.assert_raises('div >', SyntaxError)
-        self.assert_raises('div >, div', SyntaxError)
+        self.assert_raises('div >', SelectorSyntaxError)
+        self.assert_raises('div >, div', SelectorSyntaxError)
 
     @util.skip_quirks
     def test_invalid_non_quirk_combination(self):
         """Non quirk mode should not allow selectors in selector lists to start with combinators."""
 
-        self.assert_raises('> p', SyntaxError)
-        self.assert_raises('div, > a', SyntaxError)
+        self.assert_raises('> p', SelectorSyntaxError)
+        self.assert_raises('div, > a', SelectorSyntaxError)
 
 
 class TestChildQuirks(TestChild):

--- a/tests/test_level3/test_nth_child.py
+++ b/tests/test_level3/test_nth_child.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 from .. import util
 import soupsieve as sv
+from soupsieve import SelectorSyntaxError
 
 
 class TestNthChild(util.TestCase):
@@ -208,7 +209,7 @@ class TestNthChild(util.TestCase):
     def test_nth_child_with_bad_parameters(self):
         """Test that pseudo class fails with bad parameters (basically it doesn't match)."""
 
-        self.assert_raises(':nth-child(a)', SyntaxError)
+        self.assert_raises(':nth-child(a)', SelectorSyntaxError)
 
 
 class TestNthChildQuirks(TestNthChild):

--- a/tests/test_level4/test_attribute.py
+++ b/tests/test_level4/test_attribute.py
@@ -1,6 +1,7 @@
 """Test attribute selectors."""
 from __future__ import unicode_literals
 from .. import util
+from soupsieve import SelectorSyntaxError
 
 
 class TestAttribute(util.TestCase):
@@ -59,7 +60,7 @@ class TestAttribute(util.TestCase):
     def test_attribute_forced_case_needs_value(self):
         """Test attribute value case insensitivity requires a value."""
 
-        self.assert_raises('[id i]', SyntaxError)
+        self.assert_raises('[id i]', SelectorSyntaxError)
 
     def test_attribute_type_case_sensitive(self):
         """Type is treated as case insensitive in HTML, so test that we can force the opposite."""

--- a/tests/test_level4/test_has.py
+++ b/tests/test_level4/test_has.py
@@ -1,6 +1,7 @@
 """Test has selectors."""
 from __future__ import unicode_literals
 from .. import util
+from soupsieve import SelectorSyntaxError
 
 
 class TestHas(util.TestCase):
@@ -132,39 +133,39 @@ class TestHas(util.TestCase):
     def test_invalid_incomplete_has(self):
         """Test `:has()` fails with just a combinator."""
 
-        self.assert_raises(':has(>)', SyntaxError)
+        self.assert_raises(':has(>)', SelectorSyntaxError)
 
     def test_invalid_has_empty(self):
         """Test `:has()` fails with empty function parameters."""
 
-        self.assert_raises(':has()', SyntaxError)
+        self.assert_raises(':has()', SelectorSyntaxError)
 
     def test_invalid_has_double_comma(self):
         """Test `:has()` fails with consecutive commas."""
 
-        self.assert_raises(':has(> has,, a)', SyntaxError)
+        self.assert_raises(':has(> has,, a)', SelectorSyntaxError)
 
     def test_invalid_has_double_combinator(self):
         """Test `:has()` fails with consecutive combinators."""
 
-        self.assert_raises(':has(>> has a)', SyntaxError)
-        self.assert_raises(':has(> has, >> a)', SyntaxError)
-        self.assert_raises(':has(> has >> a)', SyntaxError)
+        self.assert_raises(':has(>> has a)', SelectorSyntaxError)
+        self.assert_raises(':has(> has, >> a)', SelectorSyntaxError)
+        self.assert_raises(':has(> has >> a)', SelectorSyntaxError)
 
     def test_invalid_has_trailing_combinator(self):
         """Test `:has()` fails with trailing combinator."""
 
-        self.assert_raises(':has(> has >)', SyntaxError)
+        self.assert_raises(':has(> has >)', SelectorSyntaxError)
 
     def test_invalid_has_trailing_comma(self):
         """Test `:has()` fails with trailing comma."""
 
-        self.assert_raises(':has(> has,)', SyntaxError)
+        self.assert_raises(':has(> has,)', SelectorSyntaxError)
 
     def test_invalid_has_start_comma(self):
         """Test `:has()` fails with trailing comma."""
 
-        self.assert_raises(':has(, p)', SyntaxError)
+        self.assert_raises(':has(, p)', SelectorSyntaxError)
 
 
 class TestHasQuirks(TestHas):

--- a/tests/test_level4/test_is.py
+++ b/tests/test_level4/test_is.py
@@ -1,6 +1,7 @@
 """Test is selectors."""
 from __future__ import unicode_literals
 from .. import util
+from soupsieve import SelectorSyntaxError
 
 
 class TestIs(util.TestCase):
@@ -87,23 +88,23 @@ class TestIs(util.TestCase):
     def test_invalid_pseudo_class_start_combinator(self):
         """Test invalid start combinator in pseudo-classes other than `:has()`."""
 
-        self.assert_raises(':is(> div)', SyntaxError)
-        self.assert_raises(':is(div, > div)', SyntaxError)
+        self.assert_raises(':is(> div)', SelectorSyntaxError)
+        self.assert_raises(':is(div, > div)', SelectorSyntaxError)
 
     def test_invalid_pseudo_orphan_close(self):
         """Test invalid, orphaned pseudo close."""
 
-        self.assert_raises('div)', SyntaxError)
+        self.assert_raises('div)', SelectorSyntaxError)
 
     def test_invalid_pseudo_dangling_comma(self):
         """Test pseudo class group with trailing comma."""
 
-        self.assert_raises(':is(div,)', SyntaxError)
+        self.assert_raises(':is(div,)', SelectorSyntaxError)
 
     def test_invalid_pseudo_open(self):
         """Test invalid pseudo close."""
 
-        self.assert_raises(':is(div', SyntaxError)
+        self.assert_raises(':is(div', SelectorSyntaxError)
 
 
 class TestIsQuirks(TestIs):


### PR DESCRIPTION
Refactored syntax error work done in pull #103 

The big difference here is we take control of the output opposed to relying on `SyntaxError`, which was designed for Python syntax errors, to format it for us. In the future (version 2.0) we will most likely derive from `Exception` instead of `SyntaxError`, as it is probably more appropriate for us to not confuse people by deriving from `SyntaxError`. This will allow us backwards compatibility for exception detection through the 1.0 series.