### PR TITLE
Simplify custom API and compile custom selectors "just in time"

### DIFF
--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -2,7 +2,7 @@
 
 ## 1.8.0
 
-- **NEW**: Add custom selector support. (#92)
+- **NEW**: Add custom selector support. (#92)(#108)
 - **FIX**: Small tweak to CSS identifier pattern to ensure it matches the CSS specification exactly. Specifically, you
 can't have an identifier of only `-`.
 - **FIX**: CSS string patterns should allow escaping newlines to span strings across multiple lines.

--- a/soupsieve/css_match.py
+++ b/soupsieve/css_match.py
@@ -397,7 +397,7 @@ class CSSMatch(Document, object):
         self.cached_default_forms = []
         self.cached_indeterminate_forms = []
         self.selectors = selectors
-        self.namespaces = namespaces
+        self.namespaces = {} if namespaces is None else namespaces
         self.flags = flags
         doc = scope
         parent = self.get_parent(doc)
@@ -1250,15 +1250,16 @@ class CommentsMatch(Document, object):
 class SoupSieve(ct.Immutable):
     """Compiled Soup Sieve selector matching object."""
 
-    __slots__ = ("pattern", "selectors", "namespaces", "flags", "_hash")
+    __slots__ = ("pattern", "selectors", "namespaces", "custom", "flags", "_hash")
 
-    def __init__(self, pattern, selectors, namespaces, flags):
+    def __init__(self, pattern, selectors, namespaces, custom, flags):
         """Initialize."""
 
         super(SoupSieve, self).__init__(
             pattern=pattern,
             selectors=selectors,
             namespaces=namespaces,
+            custom=custom,
             flags=flags
         )
 
@@ -1320,7 +1321,12 @@ class SoupSieve(ct.Immutable):
     def __repr__(self):  # pragma: no cover
         """Representation."""
 
-        return "SoupSieve(pattern={!r}, namespaces={!r}, flags={!r})".format(self.pattern, self.namespaces, self.flags)
+        return "SoupSieve(pattern={!r}, namespaces={!r}, custom={!r}, flags={!r})".format(
+            self.pattern,
+            self.namespaces,
+            self.custom,
+            self.flags
+        )
 
     __str__ = __repr__
 

--- a/soupsieve/css_types.py
+++ b/soupsieve/css_types.py
@@ -153,12 +153,15 @@ class CustomSelectors(ImmutableDict):
     def __init__(self, *args, **kwargs):
         """Initialize."""
 
+        # If there are arguments, check the first index.
+        # `super` should fail if the user gave multiple arguments,
+        # so don't bother checking that.
         arg = args[0] if args else kwargs
         is_dict = isinstance(arg, dict)
-        if is_dict and not all([isinstance(k, util.string) and isinstance(v, SelectorList) for k, v in arg.items()]):
-            raise TypeError('CustomSelectors keys and values must be Unicode strings and SelectorLists respectively')
-        elif not is_dict and not all([isinstance(k, util.string) and isinstance(v, SelectorList) for k, v in arg]):
-            raise TypeError('CustomSelectors keys and values must be Unicode strings and SelectorLists respectively')
+        if is_dict and not all([isinstance(k, util.string) and isinstance(v, util.string) for k, v in arg.items()]):
+            raise TypeError('CustomSelectors keys and values must be Unicode strings')
+        elif not is_dict and not all([isinstance(k, util.string) and isinstance(v, util.string) for k, v in arg]):
+            raise TypeError('CustomSelectors keys and values must be Unicode strings')
 
         super(CustomSelectors, self).__init__(*args, **kwargs)
 

--- a/soupsieve/util.py
+++ b/soupsieve/util.py
@@ -16,28 +16,19 @@ if PY3:
     import copyreg  # noqa F401
     from collections.abc import Hashable, Mapping  # noqa F401
 
-    if PY37:
-        odict = dict
-    else:
-        from collections import OrderedDict
-        odict = OrderedDict
-
     ustr = str
     bstr = bytes
     unichar = chr
     string = str
-    odict = OrderedDict if not PY37 else dict
 else:
     from backports.functools_lru_cache import lru_cache  # noqa F401
     import copy_reg as copyreg  # noqa F401
     from collections import Hashable, Mapping  # noqa F401
-    from collections import OrderedDict
 
     ustr = unicode  # noqa: F821
     bstr = str
     unichar = unichr  # noqa: F821
     string = basestring  # noqa: F821
-    odict = OrderedDict
 
 _QUIRKS = 0x20000
 DEBUG = 0x10000


### PR DESCRIPTION
After thinking about things more. If we added variable support in custom selectors we probably don't need a class, we could just do something like `{':--custom(3)': ':is(td:nth-child(3 of $1), $2, $3)'}`. Adding custom functions is probably beyond what we would even do, so limiting this to a dictionary is probably fine. We don't have such support currently, and there is no immediate plan, but this is mainly just thinking about the "maybes" in the future.

Custom selectors, if they were to use variables, they'd also need to be compiled at selector build time as the variables would be unknown.  So we also decided to go with an approach that builds the custom selectors when we need them. Currently, for the simple types of selectors we currently allow, they are cached, but if we allowed variables, we would not cache such results.
 