### PR TITLE
HTML specific selector improvements

### DIFF
--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -2,9 +2,9 @@
 
 ## 1.9.1
 
-- **FIX**: `:root`, `:default`, `:indeterminate`, `:lang()`, and `:dir()` will properly account for HTML `iframe`
-elements in their logic when selecting or matching an element. Their logic will be restricted to the document for which
-the element under consideration applies.
+- **FIX**: `:root`, `:contains()`, `:default`, `:indeterminate`, `:lang()`, and `:dir()` will properly account for HTML
+`iframe` elements in their logic when selecting or matching an element. Their logic will be restricted to the document
+for which the element under consideration applies.
 - **FIX**: HTML pseudo-classes will check that all key elements checked are in the XHTML namespace (HTML parsers that do
 not provide namespaces will assume the XHTML namespace).
 

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 1.9.1
+
+- **FIX**: HTML pseudo-classes are now aware of `iframe` elements and will not cross the `iframe` boundary. For
+instance, the `:default` pseudo-class looks for `form button` (overly simplified), but now it will not select  `form
+iframe button`. `iframe form button` is still okay as an `iframe` element's content is still accessible with
+combinators, just not within logic of an HTML pseudo-class. Notably affects `:default`, `:intermediate`, `:lang()`, and
+`:dir()`.
+- **FIX**: When using `:root`, it will apply to the root of the scoped element's document. For instance, if
+`scoped` in `#!py3 sv.select(':root div', scoped)` is an element under an `iframe`, `:root` would be the root element of
+the `iframe`.
+- **FIX**: HTML pseudo-classes will check that all key elements checked are in the XHTML namespace (HTML parsers that do
+not provide namespaces will assume the XHTML namespace).
+
 ## 1.9.0
 
 - **NEW**: Allow `:contains()` to accept a list of text to search for. (#115)

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -2,7 +2,7 @@
 
 ## 1.9.1
 
-- **FIX**: `:root`, `:default`, `:intermediate`, `:lang()`, and `:dir()` will properly account for HTML `iframe`
+- **FIX**: `:root`, `:default`, `:indeterminate`, `:lang()`, and `:dir()` will properly account for HTML `iframe`
 elements in their logic when selecting or matching an element. Their logic will be restricted to the document for which
 the element under consideration applies.
 - **FIX**: HTML pseudo-classes will check that all key elements checked are in the XHTML namespace (HTML parsers that do

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -2,14 +2,9 @@
 
 ## 1.9.1
 
-- **FIX**: HTML pseudo-classes are now aware of `iframe` elements and will not cross the `iframe` boundary. For
-instance, the `:default` pseudo-class looks for `form button` (overly simplified), but now it will not select  `form
-iframe button`. `iframe form button` is still okay as an `iframe` element's content is still accessible with
-combinators, just not within logic of an HTML pseudo-class. Notably affects `:default`, `:intermediate`, `:lang()`, and
-`:dir()`.
-- **FIX**: When using `:root`, it will apply to the root of the scoped element's document. For instance, if
-`scoped` in `#!py3 sv.select(':root div', scoped)` is an element under an `iframe`, `:root` would be the root element of
-the `iframe`.
+- **FIX**: `:root`, `:default`, `:intermediate`, `:lang()`, and `:dir()` will properly account for HTML `iframe`
+elements in their logic when selecting or matching an element. Their logic will be restricted to the document for which
+the element under consideration applies.
 - **FIX**: HTML pseudo-classes will check that all key elements checked are in the XHTML namespace (HTML parsers that do
 not provide namespaces will assume the XHTML namespace).
 

--- a/soupsieve/css_match.py
+++ b/soupsieve/css_match.py
@@ -1003,7 +1003,7 @@ class CSSMatch(Document, object):
         parent = el
         found_lang = None
         last = None
-        while parent is not None and self.get_parent(parent, no_iframe=self.is_html) and not found_lang:
+        while not found_lang:
             has_html_ns = self.has_html_ns(parent)
             for k, v in self.iter_attributes(parent):
                 attr_ns, attr = self.split_namespace(parent, k)
@@ -1022,6 +1022,8 @@ class CSSMatch(Document, object):
             if parent is None:
                 root = last
                 has_html_namespace = self.has_html_ns(root)
+                parent = last
+                break
 
         # Use cached meta language.
         if not found_lang and self.cached_meta_lang:

--- a/soupsieve/css_match.py
+++ b/soupsieve/css_match.py
@@ -198,7 +198,7 @@ class Document(object):
                 if next_good is not None:
                     if child is not next_good:
                         continue
-                    next_good is None
+                    next_good = None
 
                 is_tag = self.is_tag(child)
 
@@ -432,11 +432,12 @@ class CSSMatch(Document, object):
         iframes = []
         doc = scope
         parent = self.get_parent(doc)
+        last = doc
         while parent:
             # Store `iframe` elements we find, just in case this is an HTML document
             # and we need resolve the root relative to the scoped element (`iframe` document root).
             if util.lower(self.get_tag_name(parent)) == 'iframe':
-                iframes.append(parent)
+                iframes.append((parent, last))
             doc = parent
             parent = self.get_parent(doc)
         root = None
@@ -457,9 +458,9 @@ class CSSMatch(Document, object):
 
         # Root should be the root of the scoped element
         if self.is_html:
-            for iframe in iframes:
+            for iframe, iframe_root in iframes:
                 if self.get_tag(iframe) == 'iframe' and self.is_html_tag(iframe):
-                    self.root = iframe
+                    self.root = iframe_root
                     break
 
     def supports_namespaces(self):

--- a/soupsieve/css_match.py
+++ b/soupsieve/css_match.py
@@ -319,11 +319,12 @@ class Document(object):
             classes = RE_NOT_WS.findall(classes)
         return classes
 
-    @classmethod
-    def get_text(cls, el):
+    def get_text(self, el, no_iframe=False):
         """Get text."""
 
-        return ''.join([node for node in el.descendants if cls.is_content_string(node)])
+        return ''.join(
+            [node for node in self.get_descendants(el, tags=False, no_iframe=no_iframe) if self.is_content_string(node)]
+        )
 
 
 class Inputs(object):
@@ -880,7 +881,7 @@ class CSSMatch(Document, object):
         content = None
         for contain_list in contains:
             if content is None:
-                content = self.get_text(el)
+                content = self.get_text(el, no_iframe=self.is_html)
             found = False
             for text in contain_list.text:
                 if text in content:

--- a/soupsieve/css_match.py
+++ b/soupsieve/css_match.py
@@ -224,7 +224,8 @@ class Document(object):
                     yield child
                     if next_good is None:
                         break
-                    continue
+                    # Coverage isn't seeing this even though it's executed
+                    continue  # pragma: no cover
 
                 if not tags or is_tag:
                     yield child

--- a/soupsieve/css_parser.py
+++ b/soupsieve/css_parser.py
@@ -1053,13 +1053,13 @@ class CSSParser(object):
 
 # CSS pattern for `:link` and `:any-link`
 CSS_LINK = CSSParser(
-    ':is(a, area, link)[href]'
+    'html|*:is(a, area, link)[href]'
 ).process_selectors(flags=FLG_PSEUDO | FLG_HTML)
 # CSS pattern for `:checked`
 CSS_CHECKED = CSSParser(
     '''
-    :is(input[type=checkbox], input[type=radio])[checked],
-    select > option[selected]
+    html|*:is(input[type=checkbox], input[type=radio])[checked],
+    html|select > html|option[selected]
     '''
 ).process_selectors(flags=FLG_PSEUDO | FLG_HTML)
 # CSS pattern for `:default` (must compile CSS_CHECKED first)
@@ -1071,50 +1071,51 @@ CSS_DEFAULT = CSSParser(
     This pattern must be at the end.
     Special logic is applied to the last selector.
     */
-    form :is(button, input)[type="submit"]
+    html|form html|*:is(button, input)[type="submit"]
     '''
 ).process_selectors(flags=FLG_PSEUDO | FLG_HTML | FLG_DEFAULT)
 # CSS pattern for `:indeterminate`
 CSS_INDETERMINATE = CSSParser(
     '''
-    input[type="checkbox"][indeterminate],
-    input[type="radio"]:is(:not([name]), [name=""]):not([checked]),
-    progress:not([value]),
+    html|input[type="checkbox"][indeterminate],
+    html|input[type="radio"]:is(:not([name]), [name=""]):not([checked]),
+    html|progress:not([value]),
 
     /*
     This pattern must be at the end.
     Special logic is applied to the last selector.
     */
-    input[type="radio"][name][name!='']:not([checked])
+    html|input[type="radio"][name][name!='']:not([checked])
     '''
 ).process_selectors(flags=FLG_PSEUDO | FLG_HTML | FLG_INDETERMINATE)
 # CSS pattern for `:disabled`
 CSS_DISABLED = CSSParser(
     '''
-    :is(input[type!=hidden], button, select, textarea, fieldset, optgroup, option, fieldset)[disabled],
-    optgroup[disabled] > option,
-    fieldset[disabled] > :is(input[type!=hidden], button, select, textarea, fieldset),
-    fieldset[disabled] > :not(legend:nth-of-type(1)) :is(input[type!=hidden], button, select, textarea, fieldset)
+    html|*:is(input[type!=hidden], button, select, textarea, fieldset, optgroup, option, fieldset)[disabled],
+    html|optgroup[disabled] > html|option,
+    html|fieldset[disabled] > html|*:is(input[type!=hidden], button, select, textarea, fieldset),
+    html|fieldset[disabled] >
+        html|*:not(legend:nth-of-type(1)) html|*:is(input[type!=hidden], button, select, textarea, fieldset)
     '''
 ).process_selectors(flags=FLG_PSEUDO | FLG_HTML)
 # CSS pattern for `:enabled`
 CSS_ENABLED = CSSParser(
     '''
-    :is(input[type!=hidden], button, select, textarea, fieldset, optgroup, option, fieldset):not(:disabled)
+    html|*:is(input[type!=hidden], button, select, textarea, fieldset, optgroup, option, fieldset):not(:disabled)
     '''
 ).process_selectors(flags=FLG_PSEUDO | FLG_HTML)
 # CSS pattern for `:required`
 CSS_REQUIRED = CSSParser(
-    ':is(input, textarea, select)[required]'
+    'html|*:is(input, textarea, select)[required]'
 ).process_selectors(flags=FLG_PSEUDO | FLG_HTML)
 # CSS pattern for `:optional`
 CSS_OPTIONAL = CSSParser(
-    ':is(input, textarea, select):not([required])'
+    'html|*:is(input, textarea, select):not([required])'
 ).process_selectors(flags=FLG_PSEUDO | FLG_HTML)
 # CSS pattern for `:placeholder-shown`
 CSS_PLACEHOLDER_SHOWN = CSSParser(
     '''
-    :is(
+    html|*:is(
         input:is(
             :not([type]),
             [type=""],
@@ -1137,7 +1138,7 @@ CSS_NTH_OF_S_DEFAULT = CSSParser(
 # CSS pattern for `:read-write` (CSS_DISABLED must be compiled first)
 CSS_READ_WRITE = CSSParser(
     '''
-    :is(
+    html|*:is(
         textarea,
         input:is(
             :not([type]),
@@ -1156,19 +1157,19 @@ CSS_READ_WRITE = CSSParser(
             [type=week]
         )
     ):not([readonly], :disabled),
-    :is([contenteditable=""], [contenteditable="true" i])
+    html|*:is([contenteditable=""], [contenteditable="true" i])
     '''
 ).process_selectors(flags=FLG_PSEUDO | FLG_HTML)
 # CSS pattern for `:read-only`
 CSS_READ_ONLY = CSSParser(
     '''
-    :not(:read-write)
+    html|*:not(:read-write)
     '''
 ).process_selectors(flags=FLG_PSEUDO | FLG_HTML)
 # CSS pattern for `:in-range`
 CSS_IN_RANGE = CSSParser(
     '''
-    input:is(
+    html|input:is(
         [type="date"],
         [type="month"],
         [type="week"],
@@ -1185,7 +1186,7 @@ CSS_IN_RANGE = CSSParser(
 # CSS pattern for `:out-of-range`
 CSS_OUT_OF_RANGE = CSSParser(
     '''
-    input:is(
+    html|input:is(
         [type="date"],
         [type="month"],
         [type="week"],

--- a/tests/test_extra/test_contains.py
+++ b/tests/test_extra/test_contains.py
@@ -185,6 +185,76 @@ class TestContains(util.TestCase):
             flags=util.XML
         )
 
+    def test_contains_iframe(self):
+        """Test contains with `iframe`."""
+
+        markup = """
+        <div id="1">
+        <p>Testing text</p>
+        <iframe>
+        <html><body>
+        <span id="2">iframe</span>
+        </body></html>
+        </iframe>
+        </div>
+        """
+
+        self.assert_selector(
+            markup,
+            'div:contains("iframe")',
+            [],
+            flags=util.PYHTML
+        )
+
+        self.assert_selector(
+            markup,
+            'div:contains("text")',
+            ['1'],
+            flags=util.PYHTML
+        )
+
+        self.assert_selector(
+            markup,
+            'span:contains("iframe")',
+            ['2'],
+            flags=util.PYHTML
+        )
+
+    def test_contains_iframe_xml(self):
+        """Test contains with `iframe` which shouldn't matter in XML."""
+
+        markup = """
+        <div id="1">
+        <p>Testing text</p>
+        <iframe>
+        <html><body>
+        <span id="2">iframe</span>
+        </body></html>
+        </iframe>
+        </div>
+        """
+
+        self.assert_selector(
+            markup,
+            'div:contains("iframe")',
+            ['1'],
+            flags=util.XML
+        )
+
+        self.assert_selector(
+            markup,
+            'div:contains("text")',
+            ['1'],
+            flags=util.XML
+        )
+
+        self.assert_selector(
+            markup,
+            'span:contains("iframe")',
+            ['2'],
+            flags=util.XML
+        )
+
 
 class TestContainsQuirks(TestContains):
     """Test contains selectors with quirks."""

--- a/tests/test_level2/test_lang.py
+++ b/tests/test_level2/test_lang.py
@@ -35,6 +35,41 @@ class TestLang(util.TestCase):
             flags=util.HTML
         )
 
+    def test_iframe(self):
+        """Test language in `iframe`."""
+
+        markup = """
+        <html>
+        <body>
+        <div lang="de-DE">
+            <p id="1"></p>
+            <iframe>
+                <html>
+                <body>
+                <p id="2"></p>
+                <p id="3" lang="en-US"></p>
+                </body>
+                </html>
+            </iframe>
+        </div>
+        </body>
+        </html>
+        """
+
+        self.assert_selector(
+            markup,
+            "p:lang(en)",
+            ['3'],
+            flags=util.PYHTML
+        )
+
+        self.assert_selector(
+            markup,
+            "p:lang(de)",
+            ['1'],
+            flags=util.PYHTML
+        )
+
 
 class TestLangQuirks(TestLang):
     """Test language selector with quirks."""

--- a/tests/test_level3/test_root.py
+++ b/tests/test_level3/test_root.py
@@ -59,6 +59,17 @@ class TestRoot(util.TestCase):
             flags=util.HTML
         )
 
+    def test_root_iframe(self):
+        """Test root."""
+
+        # Root in HTML is `<html>`
+        self.assert_selector(
+            self.MARKUP_IFRAME,
+            ":root",
+            ["root", "root2"],
+            flags=util.PYHTML
+        )
+
     def test_root_complex(self):
         """Test root within a complex selector."""
 
@@ -75,14 +86,14 @@ class TestRoot(util.TestCase):
         self.assert_selector(
             self.MARKUP_IFRAME,
             ":root div",
-            ["div", "other-div"],
+            ["div", "div2", "other-div"],
             flags=util.PYHTML
         )
 
         self.assert_selector(
             self.MARKUP_IFRAME,
             ":root > body > div",
-            ["div", "other-div"],
+            ["div", "div2", "other-div"],
             flags=util.PYHTML
         )
 

--- a/tests/test_level4/test_default.py
+++ b/tests/test_level4/test_default.py
@@ -77,6 +77,47 @@ class TestDefault(util.TestCase):
             flags=util.HTML
         )
 
+    def test_iframe(self):
+        """Test with `iframe`."""
+
+        markup = """
+        <html>
+        <body>
+        <form>
+        <button id="d1" type="submit">default1</button>
+        </form>
+
+        <form>
+        <iframe>
+        <html>
+        <body>
+        <button id="d2" type="submit">default2</button>
+        </body>
+        </html>
+        </iframe>
+        <button id="d3" type="submit">default3</button>
+        </form>
+
+        <iframe>
+        <html>
+        <body>
+        <form>
+        <button id="d4" type="submit">default4</button>
+        </form>
+        </body>
+        </html>
+        </iframe>
+        </body>
+        </html>
+        """
+
+        self.assert_selector(
+            markup,
+            ":default",
+            ['d1', 'd3', 'd4'],
+            flags=util.PYHTML
+        )
+
     def test_nested_form(self):
         """
         Test nested form.

--- a/tests/test_level4/test_dir.py
+++ b/tests/test_level4/test_dir.py
@@ -139,6 +139,80 @@ class TestDir(util.TestCase):
             fragment = soup.input.extract()
             self.assertTrue(sv.match(":root:dir(ltr)", fragment, flags=sv.DEBUG))
 
+    def test_iframe(self):
+        """Test direction in `iframe`."""
+
+        markup = """
+        <html>
+        <head></head>
+        <body>
+        <div id="1" dir="auto">
+        <iframe>
+        <html>
+        <body>
+        <div id="2" dir="auto">
+        <!-- comment -->עִבְרִית
+        <span id="5" dir="auto">()</span></div>
+        </div>
+        </body>
+        </html>
+        </iframe>
+        </body>
+        </html>
+        """
+
+        self.assert_selector(
+            markup,
+            "div:dir(ltr)",
+            ['1'],
+            flags=util.PYHTML
+        )
+
+        self.assert_selector(
+            markup,
+            "div:dir(rtl)",
+            ['2'],
+            flags=util.PYHTML
+        )
+
+    def test_xml_in_html(self):
+        """Test cases for when we have XML in HTML."""
+
+        markup = """
+        <html>
+        <head></head>
+        <body>
+        <div id="1" dir="auto">
+        <math>
+        <!-- comment -->עִבְרִית
+        </math>
+        other text
+        </div>
+        </body>
+        </html>
+        """
+
+        self.assert_selector(
+            markup,
+            "div:dir(ltr)",
+            ['1'],
+            flags=util.HTML5
+        )
+
+        self.assert_selector(
+            markup,
+            "div:dir(rtl)",
+            [],
+            flags=util.HTML5
+        )
+
+        self.assert_selector(
+            markup,
+            "math:dir(rtl)",
+            [],
+            flags=util.HTML5
+        )
+
 
 class TestDirQuirks(TestDir):
     """Test direction selectors with quirks."""

--- a/tests/test_level4/test_indeterminate.py
+++ b/tests/test_level4/test_indeterminate.py
@@ -20,22 +20,22 @@ class TestIndeterminate(util.TestCase):
         </div>
         <div>
           <input type="radio" name="test" id="radio1">
-          <label for="radio">This label starts out lime.</label>
+          <label for="radio1">This label starts out lime.</label>
           <form>
             <input type="radio" name="test" id="radio2">
-            <label for="radio">This label starts out lime.</label>
+            <label for="radio2">This label starts out lime.</label>
 
             <input type="radio" name="test" id="radio3" checked>
-            <label for="radio">This label starts out lime.</label>
+            <label for="radio3">This label starts out lime.</label>
 
             <input type="radio" name="other" id="radio4">
-            <label for="radio">This label starts out lime.</label>
+            <label for="radio4">This label starts out lime.</label>
 
             <input type="radio" name="other" id="radio5">
-            <label for="radio">This label starts out lime.</label>
+            <label for="radio5">This label starts out lime.</label>
           </form>
           <input type="radio" name="test" id="radio6">
-          <label for="radio">This label starts out lime.</label>
+          <label for="radio6">This label starts out lime.</label>
         </div>
         """
 
@@ -44,6 +44,33 @@ class TestIndeterminate(util.TestCase):
             ":indeterminate",
             ['checkbox', 'radio1', 'radio6', 'radio4', 'radio5', 'radio-no-name1'],
             flags=util.HTML
+        )
+
+    def test_iframe(self):
+        """Test indeterminate when `iframe` is involved."""
+
+        markup = """
+        <form>
+            <input type="radio" name="test" id="radio1">
+            <label for="radio1">This label starts out lime.</label>
+
+            <iframe>
+            <html>
+            <body>
+            <input type="radio" name="test" id="radio2" checked>
+            <label for="radio2">This label starts out lime.</label>
+
+            <input type="radio" name="other" id="radio3">
+            <label for="radio3">This label starts out lime.</label>
+            </body>
+            </html>
+            </iframe></form>"""
+
+        self.assert_selector(
+            markup,
+            ":indeterminate",
+            ['radio1', 'radio3'],
+            flags=util.PYHTML
         )
 
 

--- a/tests/util.py
+++ b/tests/util.py
@@ -102,7 +102,7 @@ class TestCase(unittest.TestCase):
     def get_parsers(self, flags):
         """Get parsers."""
 
-        mode = flags & 0x2F
+        mode = flags & 0x3F
         if mode == HTML:
             parsers = ('html5lib', 'lxml', 'html.parser')
         elif mode == PYHTML:


### PR DESCRIPTION
Ensure that all HTML specific selectors are comparing all related
elements against the XHTML namespace. In HTML parsers that do not
provide an HTML namespace for HTML elements, assume XHTML namespace.

Ensure that :root, :contains(), :lang(), :dir(), :default, and :indeterminate all consider
iframe boundaries and do not evaluate parent or child documents when
determining whether an element matches or not.

When a scoped selector is part of an iframe, :root should match that
scoped element's document root, and not the root of the whle tree.

Reference: #138