### PR TITLE
Shortcut to last descendant if available

### DIFF
--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Next
+
+- **FIX**: Shortcut last descendant calculation if possible for performance.
+
 ## 1.9.1
 
 - **FIX**: `:root`, `:contains()`, `:default`, `:indeterminate`, `:lang()`, and `:dir()` will properly account for HTML

--- a/soupsieve/__meta__.py
+++ b/soupsieve/__meta__.py
@@ -186,5 +186,5 @@ def parse_version(ver, pre=False):
     return Version(major, minor, micro, release, pre, post, dev)
 
 
-__version_info__ = Version(1, 9, 1, "final")
+__version_info__ = Version(1, 9, 2, ".dev")
 __version__ = __version_info__._get_canonical()

--- a/soupsieve/css_match.py
+++ b/soupsieve/css_match.py
@@ -217,10 +217,13 @@ class Document(object):
                 is_tag = self.is_tag(child)
 
                 if no_iframe and is_tag and self.is_iframe(child):
-                    last_child = child
-                    while self.is_tag(last_child) and last_child.contents:
-                        last_child = last_child.contents[-1]
-                    next_good = last_child.next_element
+                    if child.next_sibling is not None:
+                        next_good = child.next_sibling
+                    else:
+                        last_child = child
+                        while self.is_tag(last_child) and last_child.contents:
+                            last_child = last_child.contents[-1]
+                        next_good = last_child.next_element
                     yield child
                     if next_good is None:
                         break


### PR DESCRIPTION
If an element has that has content we wish to skip, we have to calculate
the last descendant. Usually this is done by descending down the various
`content` members of the tags looking at their last node until we find
one that is not a tag. But we can shortcut this if the element whose
content we wish to skip has a sibling.