### PR TITLE
Add additional validation for :root selectors

### DIFF
--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -1,8 +1,10 @@
 # Changelog
 
-<!-- ## Next
+## 1.9.2
 
-- **FIX**: Shortcut last descendant calculation if possible for performance. -->
+- **FIX**: Shortcut last descendant calculation if possible for performance.
+- **FIX**: `doctype` strings should not be mistaken for a tag's content.
+- **FIX**: A tag cannot be a valid `:root` if it has sibling tags or HTML content strings.
 
 ## 1.9.1
 

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -3,8 +3,8 @@
 ## 1.9.2
 
 - **FIX**: Shortcut last descendant calculation if possible for performance.
-- **FIX**: `doctype` strings should not be mistaken for a tag's content.
-- **FIX**: A tag cannot be a valid `:root` if it has sibling tags or HTML content strings.
+- **FIX**: Fix issue where `Doctype` strings can be mistaken for a normal text node.
+- **FIX**: A top level tag is not a `:root` tag if it has sibling text nodes or tag nodes. This is an issue that mostly manifests when using the `html.parser` as it will allow multiple root nodes.
 
 ## 1.9.1
 

--- a/tests/test_level3/test_root.py
+++ b/tests/test_level3/test_root.py
@@ -118,6 +118,82 @@ class TestRoot(util.TestCase):
             ids.append(el['id'])
         self.assertEqual(sorted(ids), sorted(['div2']))
 
+    def test_no_root_double_tag(self):
+        """Test when there is no root due to double root tags."""
+
+        markup = """
+        <div id="1"></div>
+        <div id="2"></div>
+        """
+
+        soup = self.soup(markup, 'html.parser')
+        self.assertEqual(soup.select(':root'), [])
+
+    def test_no_root_text(self):
+        """Test when there is no root due to HTML text."""
+
+        markup = """
+        text
+        <div id="1"></div>
+        """
+
+        soup = self.soup(markup, 'html.parser')
+        self.assertEqual(soup.select(':root'), [])
+
+    def test_no_root_cdata(self):
+        """Test when there is no root due to CDATA and tag."""
+
+        markup = """
+        <![CDATA[test]]>
+        <div id="1"></div>
+        """
+
+        soup = self.soup(markup, 'html.parser')
+        self.assertEqual(soup.select(':root'), [])
+
+    def test_root_whitespace(self):
+        """Test when there is root and white space."""
+
+        markup = """
+
+        <div id="1"></div>
+        """
+
+        ids = []
+        soup = self.soup(markup, 'html.parser')
+        for el in soup.select(':root'):
+            ids.append(el['id'])
+        self.assertEqual(sorted(ids), sorted(['1']))
+
+    def test_root_preprocess(self):
+        """Test when there is root and pre-processing statement."""
+
+        markup = """
+        <?php ?>
+        <div id="1"></div>
+        """
+
+        ids = []
+        soup = self.soup(markup, 'html.parser')
+        for el in soup.select(':root'):
+            ids.append(el['id'])
+        self.assertEqual(sorted(ids), sorted(['1']))
+
+    def test_root_doctype(self):
+        """Test when there is root and doc type."""
+
+        markup = """
+        <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN"
+        "http://www.w3.org/TR/html4/strict.dtd">
+        <div id="1"></div>
+        """
+
+        ids = []
+        soup = self.soup(markup, 'html.parser')
+        for el in soup.select(':root'):
+            ids.append(el['id'])
+        self.assertEqual(sorted(ids), sorted(['1']))
+
 
 class TestRootQuirks(TestRoot):
     """Test root selectors with quirks."""


### PR DESCRIPTION
A valid root tag should not have sibling tags or HTML content strings.
Doctype, preprocessing strings, and whitespace can be ignored.

Fixes #145 