### PR TITLE
Remove undocumented _QUIRKS mode flag

### DIFF
--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -1,10 +1,16 @@
 # Changelog
 
+## Latest
+
+- **FIX**: Remove undocumented `_QUIRKS` mode flag as Beautiful Soup never released with support for it. Six months
+later, people have adapted to Soup Sieve's support moving forward.
+
 ## 1.9.2
 
 - **FIX**: Shortcut last descendant calculation if possible for performance.
 - **FIX**: Fix issue where `Doctype` strings can be mistaken for a normal text node in some cases.
-- **FIX**: A top level tag is not a `:root` tag if it has sibling text nodes or tag nodes. This is an issue that mostly manifests when using `html.parser` as the parser will allow multiple root nodes.
+- **FIX**: A top level tag is not a `:root` tag if it has sibling text nodes or tag nodes. This is an issue that mostly
+manifests when using `html.parser` as the parser will allow multiple root nodes.
 
 ## 1.9.1
 

--- a/soupsieve/__init__.py
+++ b/soupsieve/__init__.py
@@ -30,10 +30,10 @@ from .__meta__ import __version__, __version_info__  # noqa: F401
 from . import css_parser as cp
 from . import css_match as cm
 from . import css_types as ct
-from .util import DEBUG, _QUIRKS, deprecated, SelectorSyntaxError  # noqa: F401
+from .util import DEBUG, deprecated, SelectorSyntaxError  # noqa: F401
 
 __all__ = (
-    'DEBUG', "_QUIRKS", 'SelectorSyntaxError', 'SoupSieve',
+    'DEBUG', 'SelectorSyntaxError', 'SoupSieve',
     'closest', 'comments', 'compile', 'filter', 'icomments',
     'iselect', 'match', 'select', 'select_one'
 )

--- a/soupsieve/__meta__.py
+++ b/soupsieve/__meta__.py
@@ -186,5 +186,5 @@ def parse_version(ver, pre=False):
     return Version(major, minor, micro, release, pre, post, dev)
 
 
-__version_info__ = Version(1, 9, 2, "final")
+__version_info__ = Version(1, 9, 3, ".dev")
 __version__ = __version_info__._get_canonical()

--- a/soupsieve/css_parser.py
+++ b/soupsieve/css_parser.py
@@ -110,11 +110,6 @@ VALUE = r'''
 ATTR = r'''
 (?:{ws}*(?P<cmp>[!~^|*$]?=){ws}*(?P<value>{value})(?:{ws}+(?P<case>[is]))?)?{ws}*\]
 '''.format(ws=WSC, value=VALUE)
-# Definitions for quirks mode
-QUIRKS_ATTR_IDENTIFIER = r'(?:(?:{esc}|(?!/\*)[^"\] \t\r\n\f])+?)'.format(esc=CSS_ESCAPES)
-QUIRKS_ATTR = r'''
-(?:{ws}*(?P<cmp>[!~^|*$]?=){ws}*(?P<value>{value})(?:{ws}+(?P<case>[is]))?)?{ws}*\]
-'''.format(ws=WSC, value=QUIRKS_ATTR_IDENTIFIER)
 
 # Selector patterns
 # IDs (`#id`)
@@ -125,10 +120,6 @@ PAT_CLASS = r'\.{ident}'.format(ident=IDENTIFIER)
 PAT_TAG = r'(?:(?:{ident}|\*)?\|)?(?:{ident}|\*)'.format(ident=IDENTIFIER)
 # Attributes (`[attr]`, `[attr=value]`, etc.)
 PAT_ATTR = r'\[{ws}*(?P<ns_attr>(?:(?:{ident}|\*)?\|)?{ident}){attr}'.format(ws=WSC, ident=IDENTIFIER, attr=ATTR)
-# Quirks attributes, like real attributes, but unquoted values can contain anything but whitespace and closing `]`.
-PAT_QUIRKS_ATTR = r'''
-\[{ws}*(?P<ns_attr>(?:(?:{ident}|\*)?\|)?{ident}){attr}
-'''.format(ws=WSC, ident=IDENTIFIER, attr=QUIRKS_ATTR)
 # Pseudo class (`:pseudo-class`, `:pseudo-class(`)
 PAT_PSEUDO_CLASS = r'(?P<name>:{ident})(?P<open>\({ws}*)?'.format(ws=WSC, ident=IDENTIFIER)
 # Pseudo class special patterns. Matches `:pseudo-class(` for special case pseudo classes.
@@ -361,15 +352,6 @@ class SpecialPseudoPattern(SelectorPattern):
         return pseudo
 
 
-class QuirkPattern(SelectorPattern):
-    """Selector pattern for quirk mode."""
-
-    def enabled(self, flags):
-        """Enabled if quirks flag is present."""
-
-        return flags & util._QUIRKS
-
-
 class _Selector(object):
     """
     Intermediate selector class.
@@ -461,7 +443,6 @@ class CSSParser(object):
         SelectorPattern("class", PAT_CLASS),
         SelectorPattern("tag", PAT_TAG),
         SelectorPattern("attribute", PAT_ATTR),
-        QuirkPattern("quirks_attribute", PAT_QUIRKS_ATTR),
         SelectorPattern("combine", PAT_COMBINE)
     )
 
@@ -471,10 +452,9 @@ class CSSParser(object):
         self.pattern = selector.replace('\x00', '\ufffd')
         self.flags = flags
         self.debug = self.flags & util.DEBUG
-        self.quirks = self.flags & util._QUIRKS
         self.custom = {} if custom is None else custom
 
-    def parse_attribute_selector(self, sel, m, has_selector, quirks):
+    def parse_attribute_selector(self, sel, m, has_selector):
         """Create attribute selector from the returned regex match."""
 
         inverse = False
@@ -498,7 +478,7 @@ class CSSParser(object):
             flags = 0
 
         if op:
-            if m.group('value').startswith(('"', "'")) and not quirks:
+            if m.group('value').startswith(('"', "'")):
                 value = css_unescape(m.group('value')[1:-1], True)
             else:
                 value = css_unescape(m.group('value'))
@@ -800,21 +780,11 @@ class CSSParser(object):
         if not combinator:
             combinator = WS_COMBINATOR
         if not has_selector:
-            # The only way we don't fail is if we are at the root level and quirks mode is enabled,
-            # and we've found no other selectors yet in this compound selector.
-            if (not self.quirks or is_pseudo or combinator == COMMA_COMBINATOR or relations):
-                raise SelectorSyntaxError(
-                    "The combinator '{}' at postion {}, must have a selector before it".format(combinator, index),
-                    self.pattern,
-                    index
-                )
-            util.warn_quirks(
-                'You have attempted to use a combinator without a selector before it at position {}.'.format(index),
-                'the :scope pseudo class (or another appropriate selector) should be placed before the combinator.',
+            raise SelectorSyntaxError(
+                "The combinator '{}' at postion {}, must have a selector before it".format(combinator, index),
                 self.pattern,
                 index
             )
-            sel.flags |= ct.SEL_SCOPE
 
         if combinator == COMMA_COMBINATOR:
             if not sel.tag and not is_pseudo:
@@ -989,18 +959,8 @@ class CSSParser(object):
                         has_selector, sel = self.parse_combinator(
                             sel, m, has_selector, selectors, relations, is_pseudo, index
                         )
-                elif key in ('attribute', 'quirks_attribute'):
-                    quirks = key == 'quirks_attribute'
-                    if quirks:
-                        temp_index = index + m.group(0).find('=') + 1
-                        util.warn_quirks(
-                            "You have attempted to use an attribute " +
-                            "value that should have been quoted at position {}.".format(temp_index),
-                            "the attribute value should be quoted.",
-                            self.pattern,
-                            temp_index
-                        )
-                    has_selector = self.parse_attribute_selector(sel, m, has_selector, quirks)
+                elif key == 'attribute':
+                    has_selector = self.parse_attribute_selector(sel, m, has_selector)
                 elif key == 'tag':
                     if has_selector:
                         raise SelectorSyntaxError(
@@ -1066,8 +1026,6 @@ class CSSParser(object):
         end = (m.start(0) - 1) if m else (len(pattern) - 1)
 
         if self.debug:  # pragma: no cover
-            if self.quirks:
-                print('## QUIRKS MODE: Throwing out the spec!')
             print('## PARSING: {!r}'.format(pattern))
         while index <= end:
             m = None
@@ -1102,13 +1060,7 @@ class CSSParser(object):
             print('## END PARSING')
 
     def process_selectors(self, index=0, flags=0):
-        """
-        Process selectors.
-
-        We do our own selectors as BeautifulSoup4 has some annoying quirks,
-        and we don't really need to do nth selectors or siblings or
-        descendants etc.
-        """
+        """Process selectors."""
 
         return self.parse_selectors(self.selector_iter(self.pattern), index, flags)
 

--- a/soupsieve/util.py
+++ b/soupsieve/util.py
@@ -32,7 +32,6 @@ else:
     string = basestring  # noqa: F821
 
 DEBUG = 0x00001
-_QUIRKS = 0x10000
 
 RE_PATTERN_LINE_SPLIT = re.compile(r'(?:\r\n|(?!\r\n)[\n\r])|$')
 
@@ -169,45 +168,3 @@ def get_pattern_context(pattern, index):
         last = m.end(0)
 
     return ''.join(text), line, col
-
-
-class QuirksWarning(UserWarning):  # pragma: no cover
-    """Warning for quirks mode."""
-
-
-def warn_quirks(message, recommend, pattern, index):
-    """Warn quirks."""
-
-    import traceback
-    import bs4  # noqa: F401
-
-    # Acquire source code line context
-    paths = (MODULE, sys.modules['bs4'].__path__[0])
-    tb = traceback.extract_stack()
-    previous = None
-    filename = None
-    lineno = None
-    for entry in tb:
-        if (PY35 and entry.filename.startswith(paths)) or (not PY35 and entry[0].startswith(paths)):
-            break
-        previous = entry
-    if previous:
-        filename = previous.filename if PY35 else previous[0]
-        lineno = previous.lineno if PY35 else previous[1]
-
-    # Format pattern to show line and column position
-    context, line = get_pattern_context(pattern, index)[0:2]
-
-    # Display warning
-    warnings.warn_explicit(
-        "\nCSS selector pattern:\n" +
-        "    {}\n".format(message) +
-        "    This behavior is only allowed temporarily for Beautiful Soup's transition to Soup Sieve.\n" +
-        "    In order to confrom to the CSS spec, {}\n".format(recommend) +
-        "    It is strongly recommended the selector be altered to conform to the CSS spec " +
-        "as an exception will be raised for this case in the future.\n" +
-        "pattern line {}:\n{}".format(line, context),
-        QuirksWarning,
-        filename,
-        lineno
-    )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -667,8 +667,6 @@ class TestInvalid(util.TestCase):
         """Test bad input into the match API."""
 
         flags = sv.DEBUG
-        if self.quirks:
-            flags = sv._QUIRKS
 
         with self.assertRaises(TypeError):
             sv.match('div', "not a tag", flags=flags)
@@ -677,8 +675,6 @@ class TestInvalid(util.TestCase):
         """Test bad input into the select API."""
 
         flags = sv.DEBUG
-        if self.quirks:
-            flags = sv._QUIRKS
 
         with self.assertRaises(TypeError):
             sv.select('div', "not a tag", flags=flags)
@@ -687,8 +683,6 @@ class TestInvalid(util.TestCase):
         """Test bad input into the filter API."""
 
         flags = sv.DEBUG
-        if self.quirks:
-            flags = sv._QUIRKS
 
         with self.assertRaises(TypeError):
             sv.filter('div', "not a tag", flags=flags)
@@ -697,47 +691,9 @@ class TestInvalid(util.TestCase):
         """Test bad input into the comments API."""
 
         flags = sv.DEBUG
-        if self.quirks:
-            flags = sv._QUIRKS
 
         with self.assertRaises(TypeError):
             sv.comments('div', "not a tag", flags=flags)
-
-
-class TestInvalidQuirks(TestInvalid):
-    """Test invalid with QUIRKS."""
-
-    def setUp(self):
-        """Setup."""
-
-        sv.purge()
-        self.quirks = True
-
-    def test_quirks_warn_relative_combinator(self):
-        """Test that quirks mode raises a warning with relative combinator."""
-
-        sv.purge()
-
-        with warnings.catch_warnings(record=True) as w:
-            # Cause all warnings to always be triggered.
-            warnings.simplefilter("always")
-            # Trigger a warning.
-            sv.compile('> p', flags=sv._QUIRKS)
-            # Verify some things
-            self.assertTrue(len(w) == 1)
-            self.assertTrue(issubclass(w[-1].category, sv_util.QuirksWarning))
-
-    def test_quirks_warn_attribute_unquoted(self):
-        """Test that quirks mode raises a warning with attribute values that normally should be quoted."""
-
-        with warnings.catch_warnings(record=True) as w:
-            # Cause all warnings to always be triggered.
-            warnings.simplefilter("always")
-            # Trigger a warning.
-            sv.compile('[data={}]', flags=sv._QUIRKS)
-            # Verify some things
-            self.assertTrue(len(w) == 1)
-            self.assertTrue(issubclass(w[-1].category, sv_util.QuirksWarning))
 
 
 class TestDeprecated(util.TestCase):

--- a/tests/test_extra/test_attribute.py
+++ b/tests/test_extra/test_attribute.py
@@ -51,13 +51,3 @@ class TestAttribute(util.TestCase):
             ["div", "0", "1", "2", "3", "pre", "4", "6"],
             flags=util.HTML5
         )
-
-
-class TestAttributeQuirks(TestAttribute):
-    """Test attribute selectors with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_extra/test_contains.py
+++ b/tests/test_extra/test_contains.py
@@ -254,13 +254,3 @@ class TestContains(util.TestCase):
             ['2'],
             flags=util.XML
         )
-
-
-class TestContainsQuirks(TestContains):
-    """Test contains selectors with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_extra/test_custom.py
+++ b/tests/test_extra/test_custom.py
@@ -142,13 +142,3 @@ class TestCustomSelectors(util.TestCase):
         """Test that a custom selector cannot match an already existing custom name."""
 
         self.assert_raises('div', KeyError, custom={":--parent": ":has(> *|*)", ":--PARENT": ":has(> *|*)"})
-
-
-class TestCustomSelectorsQuirks(TestCustomSelectors):
-    """Test custom selectors with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_level1/test_active.py
+++ b/tests/test_level1/test_active.py
@@ -24,13 +24,3 @@ class TestActive(util.TestCase):
             [],
             flags=util.HTML
         )
-
-
-class TestActiveQuirks(TestActive):
-    """Test active selectors with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_level1/test_at_rule.py
+++ b/tests/test_level1/test_at_rule.py
@@ -10,13 +10,3 @@ class TestAtRule(util.TestCase):
         """Test at-rule (not supported)."""
 
         self.assert_raises('@page :left', NotImplementedError)
-
-
-class TestAtRuleQuirks(TestAtRule):
-    """Test at-rules with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_level1/test_class.py
+++ b/tests/test_level1/test_class.py
@@ -107,13 +107,3 @@ class TestClass(util.TestCase):
 
         # Malformed pseudo-class
         self.assert_raises('td:#id', SelectorSyntaxError)
-
-
-class TestClassQuirks(TestClass):
-    """Test class selectors with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_level1/test_comments.py
+++ b/tests/test_level1/test_comments.py
@@ -50,13 +50,3 @@ class TestComments(util.TestCase):
             ['1', '4', '5', '6'],
             flags=util.HTML
         )
-
-
-class TestCommentsQuirks(TestComments):
-    """Test comments with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_level1/test_descendant.py
+++ b/tests/test_level1/test_descendant.py
@@ -21,13 +21,3 @@ class TestDescendants(util.TestCase):
             ["1"],
             flags=util.HTML
         )
-
-
-class TestDescendantsQuirks(TestDescendants):
-    """Test descendant combinators with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_level1/test_escapes.py
+++ b/tests/test_level1/test_escapes.py
@@ -23,13 +23,3 @@ class TestEscapes(util.TestCase):
             ["1"],
             flags=util.HTML
         )
-
-
-class TestEscapesQuirks(TestEscapes):
-    """Test escapes with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_level1/test_id.py
+++ b/tests/test_level1/test_id.py
@@ -40,13 +40,3 @@ class TestId(util.TestCase):
 
         # Malformed id
         self.assert_raises('td#.some-class', SelectorSyntaxError)
-
-
-class TestIdQuirks(TestId):
-    """Test ID selectors with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_level1/test_link.py
+++ b/tests/test_level1/test_link.py
@@ -41,13 +41,3 @@ class TestLink(util.TestCase):
             [],
             flags=util.XML
         )
-
-
-class TestLinkQuirks(TestLink):
-    """Test link selectors with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_level1/test_list.py
+++ b/tests/test_level1/test_list.py
@@ -37,13 +37,3 @@ class TestSelectorLists(util.TestCase):
         """Test that selectors cannot have double combinators."""
 
         self.assert_raises('div,, a', SelectorSyntaxError)
-
-
-class TestSelectorListsQuirks(TestSelectorLists):
-    """Test selector lists with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_level1/test_pseudo_class.py
+++ b/tests/test_level1/test_pseudo_class.py
@@ -15,13 +15,3 @@ class TestPseudoClass(util.TestCase):
         """Test unrecognized pseudo class."""
 
         self.assert_raises(':before', NotImplementedError)
-
-
-class TestPseudoClassQuirks(TestPseudoClass):
-    """Test pseudo-classes with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_level1/test_pseudo_element.py
+++ b/tests/test_level1/test_pseudo_element.py
@@ -10,13 +10,3 @@ class TestPseudoElement(util.TestCase):
         """Test that pseudo elements always fail because they are not supported."""
 
         self.assert_raises('::first-line', NotImplementedError)
-
-
-class TestPseudoElementQuirks(TestPseudoElement):
-    """Test pseudo-elements with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_level1/test_type.py
+++ b/tests/test_level1/test_type.py
@@ -106,13 +106,3 @@ class TestType(util.TestCase):
 
         self.assert_raises('div?', SelectorSyntaxError)
         self.assert_raises('-', SelectorSyntaxError)
-
-
-class TestTypeQuirks(TestType):
-    """Test type selectors with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_level1/test_visited.py
+++ b/tests/test_level1/test_visited.py
@@ -24,13 +24,3 @@ class TestVisited(util.TestCase):
             [],
             flags=util.HTML
         )
-
-
-class TestVisitedQuirks(TestVisited):
-    """Test visited selectors with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_level2/test_attribute.py
+++ b/tests/test_level2/test_attribute.py
@@ -195,9 +195,8 @@ class TestAttribute(util.TestCase):
 
         self.assert_raises('[href]p', SelectorSyntaxError)
 
-    @util.skip_quirks
-    def test_malformed_no_quirk(self):
-        """Test malformed with no quirk mode."""
+    def test_malformed(self):
+        """Test malformed."""
 
         # Malformed attribute
         self.assert_raises('div[attr={}]', SelectorSyntaxError)
@@ -370,38 +369,5 @@ class TestAttribute(util.TestCase):
             self.MARKUP_CONTAINS,
             '[class~="test1\\ test2"]',
             [],
-            flags=util.HTML
-        )
-
-
-class TestAttributeQuirks(TestAttribute):
-    """Test attribute selector with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True
-
-    def test_attribute_quirks(self):
-        """Test attributes with quirks."""
-
-        markup = """
-        <div id="div">
-        <p id="0">Some text <span id="1"> in a paragraph</span>.</p>
-        <a id="2" href="{}?/">Link</a>
-        <span id="3">Direct child</span>
-        <pre id="pre">
-        <span id="4">Child 1</span>
-        <span id="5">Child 2</span>
-        <span id="6">Child 3</span>
-        </pre>
-        </div>
-        """
-
-        self.assert_selector(
-            markup,
-            "[href={}?/]",
-            ["2"],
             flags=util.HTML
         )

--- a/tests/test_level2/test_child.py
+++ b/tests/test_level2/test_child.py
@@ -55,49 +55,8 @@ class TestChild(util.TestCase):
         self.assert_raises('div >', SelectorSyntaxError)
         self.assert_raises('div >, div', SelectorSyntaxError)
 
-    @util.skip_quirks
-    def test_invalid_non_quirk_combination(self):
-        """Non quirk mode should not allow selectors in selector lists to start with combinators."""
+    def test_invalid_combinator(self):
+        """Test that we do not allow selectors in selector lists to start with combinators."""
 
         self.assert_raises('> p', SelectorSyntaxError)
         self.assert_raises('div, > a', SelectorSyntaxError)
-
-
-class TestChildQuirks(TestChild):
-    """Test child combinators with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True
-
-    @util.requires_html5lib
-    def test_leading_combinator_quirks(self):
-        """Test scope with quirks."""
-
-        markup = """
-        <html id="root">
-        <head>
-        </head>
-        <body>
-        <div id="div">
-        <p id="0" class="somewordshere">Some text <span id="1"> in a paragraph</span>.</p>
-        <a id="2" href="http://google.com">Link</a>
-        <span id="3" class="herewords">Direct child</span>
-        <pre id="pre" class="wordshere">
-        <span id="4">Child 1</span>
-        <span id="5">Child 2</span>
-        <span id="6">Child 3</span>
-        </pre>
-        </div>
-        </body>
-        </html>
-        """
-
-        soup = self.soup(markup, 'html5lib')
-        el = soup.div
-        ids = []
-        for el in sv.select('> span, > #pre', el, flags=sv.DEBUG | sv._QUIRKS):
-            ids.append(el.attrs['id'])
-        self.assertEqual(sorted(ids), sorted(['3', 'pre']))

--- a/tests/test_level2/test_child.py
+++ b/tests/test_level2/test_child.py
@@ -1,7 +1,6 @@
 """Test child combinators."""
 from __future__ import unicode_literals
 from .. import util
-import soupsieve as sv
 from soupsieve import SelectorSyntaxError
 
 

--- a/tests/test_level2/test_first_child.py
+++ b/tests/test_level2/test_first_child.py
@@ -26,13 +26,3 @@ class TestFirstChild(util.TestCase):
             ["1", "4"],
             flags=util.HTML
         )
-
-
-class TestFirstChildQuirks(TestFirstChild):
-    """Test first child selector with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_level2/test_focus.py
+++ b/tests/test_level2/test_focus.py
@@ -54,13 +54,3 @@ class TestFocus(util.TestCase):
             ["1", "2", "3", "4", "5", "6"],
             flags=util.HTML
         )
-
-
-class TestFocusQuirks(TestFocus):
-    """Test focus selector with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_level2/test_hover.py
+++ b/tests/test_level2/test_hover.py
@@ -24,13 +24,3 @@ class TestHover(util.TestCase):
             [],
             flags=util.HTML
         )
-
-
-class TestHoverQuirks(TestHover):
-    """Test hover selector with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_level2/test_lang.py
+++ b/tests/test_level2/test_lang.py
@@ -69,13 +69,3 @@ class TestLang(util.TestCase):
             ['1'],
             flags=util.PYHTML
         )
-
-
-class TestLangQuirks(TestLang):
-    """Test language selector with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_level2/test_next_sibling.py
+++ b/tests/test_level2/test_next_sibling.py
@@ -51,13 +51,3 @@ class TestNextSibling(util.TestCase):
             ["5"],
             flags=util.HTML
         )
-
-
-class TestNextSiblingQuirks(TestNextSibling):
-    """Test next sibling combinators with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_level2/test_universal_type.py
+++ b/tests/test_level2/test_universal_type.py
@@ -28,13 +28,3 @@ class TestUniversal(util.TestCase):
             ["0", "1", "2", "3", "4", "5", "6", "div", "pre"],
             flags=util.HTML
         )
-
-
-class TestUniversalQuirks(TestUniversal):
-    """Test universal type selector with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_level3/test_attribute.py
+++ b/tests/test_level3/test_attribute.py
@@ -61,13 +61,3 @@ class TestAttribute(util.TestCase):
             ["0", "3", "pre"],
             flags=util.HTML
         )
-
-
-class TestAttributeQuirks(TestAttribute):
-    """Test attribute selectors with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_level3/test_checked.py
+++ b/tests/test_level3/test_checked.py
@@ -38,13 +38,3 @@ class TestChecked(util.TestCase):
             ['yes', 'opt-in', '2'],
             flags=util.HTML
         )
-
-
-class TestCheckedQuirks(TestChecked):
-    """Test checked selectors with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_level3/test_disabled.py
+++ b/tests/test_level3/test_disabled.py
@@ -143,13 +143,3 @@ class TestDisabled(util.TestCase):
             ['4', '5', '6', '7', '8', '9', 'a', 'c'],
             flags=util.PYHTML
         )
-
-
-class TestDisabledQuirks(TestDisabled):
-    """Test disabled selectors with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_level3/test_empty.py
+++ b/tests/test_level3/test_empty.py
@@ -31,13 +31,3 @@ class TestEmpty(util.TestCase):
             ["4", "5", "6", "8"],
             flags=util.HTML
         )
-
-
-class TestEmptyQuirks(TestEmpty):
-    """Test empty selectors with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_level3/test_enabled.py
+++ b/tests/test_level3/test_enabled.py
@@ -145,13 +145,3 @@ class TestEnabled(util.TestCase):
             ['1', '2', 'opt-enable', 'b', '3'],
             flags=util.PYHTML
         )
-
-
-class TestEnabledQuirks(TestEnabled):
-    """Test enabled selectors with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_level3/test_first_of_type.py
+++ b/tests/test_level3/test_first_of_type.py
@@ -85,13 +85,3 @@ class TestFirstOfType(util.TestCase):
             ['0', '2'],
             flags=util.HTML
         )
-
-
-class TestFirstOfTypeQuirks(TestFirstOfType):
-    """Test first of type selectors with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_level3/test_last_child.py
+++ b/tests/test_level3/test_last_child.py
@@ -38,13 +38,3 @@ class TestLastChild(util.TestCase):
             ["1", "6"],
             flags=util.HTML
         )
-
-
-class TestLastChildQuirks(TestLastChild):
-    """Test last child selectors with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_level3/test_last_of_type.py
+++ b/tests/test_level3/test_last_of_type.py
@@ -86,13 +86,3 @@ class TestLastOfType(util.TestCase):
             ['10', '11'],
             flags=util.HTML
         )
-
-
-class TestLastOfTypeQuirks(TestLastOfType):
-    """Test last of type selectors with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_level3/test_namespace.py
+++ b/tests/test_level3/test_namespace.py
@@ -341,13 +341,3 @@ class TestNamespace(util.TestCase):
             namespaces={"xlink": "http://www.w3.org/1999/xlink"},
             flags=util.XHTML
         )
-
-
-class TestNamespaceQuirks(TestNamespace):
-    """Test namespace selectors with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_level3/test_not.py
+++ b/tests/test_level3/test_not.py
@@ -48,13 +48,3 @@ class TestNot(util.TestCase):
             ["0", "2", "3", "4", "5", "6", "pre"],
             flags=util.HTML
         )
-
-
-class TestNotQuirks(TestNot):
-    """Test not selectors with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_level3/test_nth_child.py
+++ b/tests/test_level3/test_nth_child.py
@@ -245,13 +245,3 @@ class TestNthChild(util.TestCase):
         """Test that pseudo class fails with bad parameters (basically it doesn't match)."""
 
         self.assert_raises(':nth-child(a)', SelectorSyntaxError)
-
-
-class TestNthChildQuirks(TestNthChild):
-    """Test `nth` child selectors with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_level3/test_nth_last_child.py
+++ b/tests/test_level3/test_nth_last_child.py
@@ -59,13 +59,3 @@ class TestNthLastChild(util.TestCase):
             ['1', '7', '9'],
             flags=util.HTML
         )
-
-
-class TestNthLastChildQuirks(TestNthLastChild):
-    """Test `nth` last child selectors with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_level3/test_nth_last_of_type.py
+++ b/tests/test_level3/test_nth_last_of_type.py
@@ -55,13 +55,3 @@ class TestNthLastOfType(util.TestCase):
             ['1', '8', '10'],
             flags=util.HTML
         )
-
-
-class TestNthLastOfTypeQuirks(TestNthLastOfType):
-    """Test `nth` last of type selectors with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_level3/test_nth_of_type.py
+++ b/tests/test_level3/test_nth_of_type.py
@@ -73,13 +73,3 @@ class TestNthOfType(util.TestCase):
             ['0', '2', '4', '6', '7', '9'],
             flags=util.HTML
         )
-
-
-class TestNthOfTypeQuirks(TestNthOfType):
-    """Test `nth` of type selectors with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_level3/test_only_child.py
+++ b/tests/test_level3/test_only_child.py
@@ -26,13 +26,3 @@ class TestOnlyChild(util.TestCase):
             ["1"],
             flags=util.HTML
         )
-
-
-class TestOnlyChildQuirks(TestOnlyChild):
-    """Test only child selectors with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_level3/test_only_of_type.py
+++ b/tests/test_level3/test_only_of_type.py
@@ -30,13 +30,3 @@ class TestOnlyOfType(util.TestCase):
             ['1', '4'],
             flags=util.HTML
         )
-
-
-class TestOnlyOfTypeQuirks(TestOnlyOfType):
-    """Test only of type selectors with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_level3/test_root.py
+++ b/tests/test_level3/test_root.py
@@ -193,13 +193,3 @@ class TestRoot(util.TestCase):
         for el in soup.select(':root'):
             ids.append(el['id'])
         self.assertEqual(sorted(ids), sorted(['1']))
-
-
-class TestRootQuirks(TestRoot):
-    """Test root selectors with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_level3/test_subsequent_sibling.py
+++ b/tests/test_level3/test_subsequent_sibling.py
@@ -26,13 +26,3 @@ class TestSubsequentSibling(util.TestCase):
             ["3"],
             flags=util.HTML
         )
-
-
-class TestSubsequentSiblingQuirks(TestSubsequentSibling):
-    """Test subsequent sibling combinator with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_level3/test_target.py
+++ b/tests/test_level3/test_target.py
@@ -34,13 +34,3 @@ class TestTarget(util.TestCase):
             ["head-2"],
             flags=util.HTML
         )
-
-
-class TestTargetQuirks(TestTarget):
-    """Test target selectors with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_level4/test_any_link.py
+++ b/tests/test_level4/test_any_link.py
@@ -54,13 +54,3 @@ class TestAnyLink(util.TestCase):
             ["div", "0", "1", "2", "3"],
             flags=util.XML
         )
-
-
-class TestAnyLinkQuirks(TestAnyLink):
-    """Test any link selectors with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_level4/test_attribute.py
+++ b/tests/test_level4/test_attribute.py
@@ -71,13 +71,3 @@ class TestAttribute(util.TestCase):
             ['2'],
             flags=util.HTML
         )
-
-
-class TestAttributeQuirks(TestAttribute):
-    """Test attribute selectors with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_level4/test_current.py
+++ b/tests/test_level4/test_current.py
@@ -70,13 +70,3 @@ class TestCurrent(util.TestCase):
             ["div", "0", "1", "2", "3"],
             flags=util.HTML
         )
-
-
-class TestCurrentQuirks(TestCurrent):
-    """Test current selectors with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_level4/test_default.py
+++ b/tests/test_level4/test_default.py
@@ -205,13 +205,3 @@ class TestDefault(util.TestCase):
             [],
             flags=util.HTML
         )
-
-
-class TestDefaultQuirks(TestDefault):
-    """Test default selectors with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_level4/test_defined.py
+++ b/tests/test_level4/test_defined.py
@@ -88,13 +88,3 @@ class TestDefined(util.TestCase):
             [],
             flags=util.XML
         )
-
-
-class TestDefinedQuirks(TestDefined):
-    """Test defined selectors with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_level4/test_dir.py
+++ b/tests/test_level4/test_dir.py
@@ -212,13 +212,3 @@ class TestDir(util.TestCase):
             [],
             flags=util.HTML5
         )
-
-
-class TestDirQuirks(TestDir):
-    """Test direction selectors with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_level4/test_focus_visible.py
+++ b/tests/test_level4/test_focus_visible.py
@@ -31,13 +31,3 @@ class TestFocusVisible(util.TestCase):
             ["form"],
             flags=util.HTML
         )
-
-
-class TestFocusVisibleQuirks(TestFocusVisible):
-    """Test focus visible selectors with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_level4/test_focus_within.py
+++ b/tests/test_level4/test_focus_within.py
@@ -31,13 +31,3 @@ class TestFocusWithin(util.TestCase):
             ["form"],
             flags=util.HTML
         )
-
-
-class TestFocusWithinQuirks(TestFocusWithin):
-    """Test focus within selectors with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_level4/test_future.py
+++ b/tests/test_level4/test_future.py
@@ -36,13 +36,3 @@ class TestFuture(util.TestCase):
             ["0"],
             flags=util.HTML
         )
-
-
-class TestFutureQuirks(TestFuture):
-    """Test future selectors with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_level4/test_has.py
+++ b/tests/test_level4/test_has.py
@@ -166,13 +166,3 @@ class TestHas(util.TestCase):
         """Test `:has()` fails with trailing comma."""
 
         self.assert_raises(':has(, p)', SelectorSyntaxError)
-
-
-class TestHasQuirks(TestHas):
-    """Test has selectors with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_level4/test_host.py
+++ b/tests/test_level4/test_host.py
@@ -27,13 +27,3 @@ class TestHost(util.TestCase):
             [],
             flags=util.HTML
         )
-
-
-class TestHostQuirks(TestHost):
-    """Test host selectors with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_level4/test_host_context.py
+++ b/tests/test_level4/test_host_context.py
@@ -17,13 +17,3 @@ class TestHostContext(util.TestCase):
             [],
             flags=util.HTML
         )
-
-
-class TestHostContextQuirks(TestHostContext):
-    """Test host context selectors with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_level4/test_in_range.py
+++ b/tests/test_level4/test_in_range.py
@@ -236,13 +236,3 @@ class TestInRange(util.TestCase):
             ['0', '1', '2', '3', '4', '5', '6', '7'],
             flags=util.HTML
         )
-
-
-class TestInRangeQuirks(TestInRange):
-    """Test in range selectors with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_level4/test_indeterminate.py
+++ b/tests/test_level4/test_indeterminate.py
@@ -72,13 +72,3 @@ class TestIndeterminate(util.TestCase):
             ['radio1', 'radio3'],
             flags=util.PYHTML
         )
-
-
-class TestIndeterminateQuirks(TestIndeterminate):
-    """Test indeterminate selectors with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_level4/test_is.py
+++ b/tests/test_level4/test_is.py
@@ -25,22 +25,12 @@ class TestIs(util.TestCase):
             flags=util.HTML
         )
 
-    def test_matches(self):
-        """Test multiple selectors with the "matches" alias."""
-
-        self.assert_selector(
-            self.MARKUP,
-            ":matches(span, a)",
-            ["1", "2"],
-            flags=util.HTML
-        )
-
     def test_nested_is(self):
         """Test multiple nested selectors."""
 
         self.assert_selector(
             self.MARKUP,
-            ":is(span, a:matches(#\\32))",
+            ":is(span, a:is(#\\32))",
             ["1", "2"],
             flags=util.HTML
         )
@@ -105,13 +95,3 @@ class TestIs(util.TestCase):
         """Test invalid pseudo close."""
 
         self.assert_raises(':is(div', SelectorSyntaxError)
-
-
-class TestIsQuirks(TestIs):
-    """Test is selectors with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_level4/test_lang.py
+++ b/tests/test_level4/test_lang.py
@@ -313,13 +313,3 @@ class TestLang(util.TestCase):
             [],
             flags=util.XHTML
         )
-
-
-class TestLangQuirks(TestLang):
-    """Test language selectors with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_level4/test_local_link.py
+++ b/tests/test_level4/test_local_link.py
@@ -30,13 +30,3 @@ class TestLocalLink(util.TestCase):
             ["1", "2"],
             flags=util.HTML
         )
-
-
-class TestLocalLinkQuirks(TestLocalLink):
-    """Test local link selectors with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_level4/test_matches.py
+++ b/tests/test_level4/test_matches.py
@@ -6,12 +6,30 @@ from .. import util
 class TestMatches(util.TestCase):
     """Test matches selectors."""
 
+    MARKUP = """
+    <div>
+    <p>Some text <span id="1"> in a paragraph</span>.
+    <a id="2" href="http://google.com">Link</a>
+    </p>
+    </div>
+    """
 
-class TestMatchesQuirks(TestMatches):
-    """Test matches selectors with quirks."""
+    def test_matches(self):
+        """Test multiple selectors with "matches"."""
 
-    def setUp(self):
-        """Setup."""
+        self.assert_selector(
+            self.MARKUP,
+            ":matches(span, a)",
+            ["1", "2"],
+            flags=util.HTML
+        )
 
-        self.purge()
-        self.quirks = True
+    def test_nested_matches(self):
+        """Test multiple nested selectors with "matches"."""
+
+        self.assert_selector(
+            self.MARKUP,
+            ":matches(span, a:matches(#\\32))",
+            ["1", "2"],
+            flags=util.HTML
+        )

--- a/tests/test_level4/test_not.py
+++ b/tests/test_level4/test_not.py
@@ -28,13 +28,3 @@ class TestNot(util.TestCase):
             ['5'],
             flags=util.HTML
         )
-
-
-class TestNotQuirks(TestNot):
-    """Test not selectors with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_level4/test_nth_child.py
+++ b/tests/test_level4/test_nth_child.py
@@ -47,13 +47,3 @@ class TestNthChild(util.TestCase):
             ['2', '6', '10'],
             flags=util.HTML
         )
-
-
-class TestNthChildQuirks(TestNthChild):
-    """Test `nth` child selectors with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_level4/test_optional.py
+++ b/tests/test_level4/test_optional.py
@@ -37,13 +37,3 @@ class TestOptional(util.TestCase):
             ['3'],
             flags=util.HTML
         )
-
-
-class TestOptionalQuirks(TestOptional):
-    """Test optional selectors with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_level4/test_out_of_range.py
+++ b/tests/test_level4/test_out_of_range.py
@@ -236,13 +236,3 @@ class TestOutOfRange(util.TestCase):
             ['8', '9', '10', '11', '12', '13', '14'],
             flags=util.HTML
         )
-
-
-class TestOutOfRangeQuirks(TestOutOfRange):
-    """Test out of range selectors with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_level4/test_past.py
+++ b/tests/test_level4/test_past.py
@@ -36,13 +36,3 @@ class TestPast(util.TestCase):
             ["0"],
             flags=util.HTML
         )
-
-
-class TestPastQuirks(TestPast):
-    """Test past selectors with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_level4/test_paused.py
+++ b/tests/test_level4/test_paused.py
@@ -41,13 +41,3 @@ class TestPaused(util.TestCase):
             ["vid"],
             flags=util.HTML
         )
-
-
-class TestPausedQuirks(TestPaused):
-    """Test paused selectors with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_level4/test_placeholder_shown.py
+++ b/tests/test_level4/test_placeholder_shown.py
@@ -49,13 +49,3 @@ class TestPlaceholderShown(util.TestCase):
             ['0', '1', '4', '5', '6', '7', '8', '9', '10', '11', '12'],
             flags=util.HTML
         )
-
-
-class TestPlaceholderShownQuirks(TestPlaceholderShown):
-    """Test placeholder shown selectors with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_level4/test_playing.py
+++ b/tests/test_level4/test_playing.py
@@ -41,13 +41,3 @@ class TestPlaying(util.TestCase):
             ["vid"],
             flags=util.HTML
         )
-
-
-class TestPlayingQuirks(TestPlaying):
-    """Test playing selectors with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_level4/test_read_only.py
+++ b/tests/test_level4/test_read_only.py
@@ -62,13 +62,3 @@ class TestReadOnly(util.TestCase):
             ],
             flags=util.HTML
         )
-
-
-class TestReadOnlyQuirks(TestReadOnly):
-    """Test read only selectors with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_level4/test_read_write.py
+++ b/tests/test_level4/test_read_write.py
@@ -60,13 +60,3 @@ class TestReadWrite(util.TestCase):
             ],
             flags=util.HTML
         )
-
-
-class TestReadWriteQuirks(TestReadWrite):
-    """Test read write selectors with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_level4/test_required.py
+++ b/tests/test_level4/test_required.py
@@ -37,13 +37,3 @@ class TestRequired(util.TestCase):
             ['1', '2'],
             flags=util.HTML
         )
-
-
-class TestRequiredQuirks(TestRequired):
-    """Test required selectors with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_level4/test_scope.py
+++ b/tests/test_level4/test_scope.py
@@ -87,13 +87,3 @@ class TestScope(util.TestCase):
             for el in sv.select(':scope .wordshere', el, flags=sv.DEBUG):
                 ids.append(el.attrs['id'])
             self.assertEqual(sorted(ids), sorted(['pre']))
-
-
-class TestScopeQuirks(TestScope):
-    """Test scope selectors with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_level4/test_target_within.py
+++ b/tests/test_level4/test_target_within.py
@@ -35,13 +35,3 @@ class TestTargetWithin(util.TestCase):
             ["article"],
             flags=util.HTML
         )
-
-
-class TestTargetWithinQuirks(TestTargetWithin):
-    """Test target within selectors with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_level4/test_user_invalid.py
+++ b/tests/test_level4/test_user_invalid.py
@@ -28,13 +28,3 @@ class TestInvalid(util.TestCase):
             ["1"],
             flags=util.HTML
         )
-
-
-class TestInvalidQuirks(TestInvalid):
-    """Test invalid selectors with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/test_level4/test_where.py
+++ b/tests/test_level4/test_where.py
@@ -33,13 +33,3 @@ class TestWhere(util.TestCase):
             ["1", "2"],
             flags=util.HTML
         )
-
-
-class TestWhereQuirks(TestWhere):
-    """Test where selectors with quirks."""
-
-    def setUp(self):
-        """Setup."""
-
-        self.purge()
-        self.quirks = True

--- a/tests/util.py
+++ b/tests/util.py
@@ -30,18 +30,6 @@ PYHTML = 0x10
 LXML_HTML = 0x20
 
 
-def skip_quirks(func):
-    """Decorator that skips when quirks mode is enabled."""
-
-    def skip_if(self, *args, **kwargs):
-        """Skip conditional wrapper."""
-        if self.quirks is True:
-            raise pytest.skip('not applicable to quirks mode')
-        else:
-            return func(self, *args, **kwargs)
-    return skip_if
-
-
 def skip_py3(func):
     """Decorator that skips when running in Python 3."""
 
@@ -77,7 +65,6 @@ class TestCase(unittest.TestCase):
         """Setup."""
 
         sv.purge()
-        self.quirks = False
 
     def purge(self):
         """Purge cache."""
@@ -89,8 +76,6 @@ class TestCase(unittest.TestCase):
 
         print('PATTERN: ', selectors)
         flags |= sv.DEBUG
-        if self.quirks:
-            flags |= sv._QUIRKS
         return sv.compile(selectors, namespaces=namespaces, custom=custom, flags=flags)
 
     def soup(self, markup, parser):


### PR DESCRIPTION
Beautiful Soup never released with the ability to use _QUIRKS mode,
and we purposely never documented _QUIRKS mode as we only wanted it to
work directly with Beautiful Soup's API. It was only meant to be used
during the transition period from legacy CSS support to Soup Sieve
support. But six months later, people have gotten used to the new CSS
support without _QUIRKS mode.