### PR TITLE
Fix [attr!=value]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,8 @@ matrix:
     env: TOXENV=lint
   - python: 3.7
     env: TOXENV=documents
+  allow_failures:
+  - python: 3.8-dev
 
 addons:
   apt:

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -1,9 +1,10 @@
 # Changelog
 
-## Latest
+## 1.9.3
 
-- **FIX**: Remove undocumented `_QUIRKS` mode flag as Beautiful Soup never released with support for it. Six months
-later, people have adapted to Soup Sieve's support moving forward.
+- **FIX**: `[attr!=value]` pattern was mistakenly using `:not([attr|=value])` logic instead of `:not([attr=value])`.
+- **FIX**: Remove undocumented `_QUIRKS` mode flag. Beautiful Soup was meant to use it to help with transition to Soup
+Sieve, but never released with it. Help with transition at this point is no longer needed.
 
 ## 1.9.2
 

--- a/soupsieve/css_parser.py
+++ b/soupsieve/css_parser.py
@@ -505,13 +505,12 @@ class CSSParser(object):
         elif op.startswith('|'):
             # Value starts with word in dash separated list
             pattern = re.compile(r'^%s(?:-.*)?$' % re.escape(value), flags)
-        elif op.startswith('!'):
-            # Equivalent to `:not([attr=value])`
-            pattern = re.compile(r'^%s(?:-.*)?$' % re.escape(value), flags)
-            inverse = True
         else:
             # Value matches
             pattern = re.compile(r'^%s$' % re.escape(value), flags)
+            if op.startswith('!'):
+                # Equivalent to `:not([attr=value])`
+                inverse = True
         if is_type and pattern:
             pattern2 = re.compile(pattern.pattern)
 


### PR DESCRIPTION
`[attr!=value]` pattern was mistakenly using `:not([attr|=value])` logic
instead of `:not([attr=value])`