### PR TITLE
Fix tests for lxml 4.4.0+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,6 @@ matrix:
   - python: 2.7
     env:
     - TOXENV=py27
-  - python: 3.4
-    env:
-    - TOXENV=py34
   - python: 3.5
     env:
     - TOXENV=py35

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,15 +6,13 @@ environment:
   matrix:
     - PYTHON: "C:/Python27"
       TOXENV: "py27"
-    - PYTHON: "C:/Python34"
-      TOXENV: "py34"
     - PYTHON: "C:/Python35"
       TOXENV: "py35"
     - PYTHON: "C:/Python36"
       TOXENV: "py36"
     - PYTHON: "C:/Python37"
       TOXENV: "py37"
-    - PYTHON: "C:/Python36"
+    - PYTHON: "C:/Python37"
       TOXENV: "lint"
 
 init:

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/tests/test_level4/test_defined.py
+++ b/tests/test_level4/test_defined.py
@@ -45,21 +45,23 @@ class TestDefined(util.TestCase):
         <div-custom id="1"></div-custom>
         <prefix:div id="2"></prefix:div>
         <!--
-        lxml or BeautifulSoup seems to strip away the prefix.
-        This is most likely because prefix with no namespace is not really valid.
+        lxml seems to strip away the prefix in versions less than 4.4.0.
+        This was most likely because prefix with no namespace is not really valid.
         XML does allow colons in names, but encourages them to be used for namespaces.
-        Do we really care that the prefix is wiped out in XHTML if there is no namespace?
-        If we do, we should look into this in the future.
+        This is a quirk of LXML, but it appears to be fine in 4.4.0+.
         -->
         <prefix:div-custom id="3"></prefix:div-custom>
         </body>
         </html>
         """
 
+        from lxml import etree
+
         self.assert_selector(
             markup,
             'body :defined',
-            ['0', '2'],  # We should get 3, but we don't for reasons stated above.
+            # We should get 3, but for LXML versions less than 4.4.0 we don't for reasons stated above.
+            ['0', '2'] if etree.LXML_VERSION < (4, 4, 0, 0) else ['0', '1', '2'],
             flags=util.XHTML
         )
 

--- a/tests/test_level4/test_defined.py
+++ b/tests/test_level4/test_defined.py
@@ -30,6 +30,7 @@ class TestDefined(util.TestCase):
             flags=util.HTML
         )
 
+    @util.skip_no_lxml
     def test_defined_xhtml(self):
         """Test defined XHTML."""
 

--- a/tests/util.py
+++ b/tests/util.py
@@ -42,6 +42,18 @@ def skip_py3(func):
     return skip_if
 
 
+def skip_no_lxml(func):
+    """Decorator that skips lxml is not available."""
+
+    def skip_if(self, *args, **kwargs):
+        """Skip conditional wrapper."""
+
+        if LXML_PRESENT:
+            return func(self, *args, **kwargs)
+        else:
+            raise pytest.skip('lxml is not found')
+
+
 class TestCase(unittest.TestCase):
     """Test case."""
 


### PR DESCRIPTION
It seems that LXML addressed a quirk we had noticed in our tests. Now
it behaves more like we would expect.