### PR TITLE
Lang wildcard start

### DIFF
--- a/docs/src/dictionary/en-custom.txt
+++ b/docs/src/dictionary/en-custom.txt
@@ -59,6 +59,8 @@ pytest
 regex
 sublicense
 substring
+subtag
+subtags
 traceback
 tuple
 tuples

--- a/docs/src/dictionary/en-custom.txt
+++ b/docs/src/dictionary/en-custom.txt
@@ -1,6 +1,7 @@
 API
 Accessors
 Aspell
+BCP
 BeautifulSoup
 CDATA
 CSS

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.9.4
+
+- **FIX**: Fix `:lang()` wildcard matching when applied to the primary language tag (i.e. `:lang('*-US')`). When a
+wildcard is applied at the start of the pattern, it should match zero or more, not one or more.
+
 ## 1.9.3
 
 - **FIX**: `[attr!=value]` pattern was mistakenly using `:not([attr|=value])` logic instead of `:not([attr=value])`.

--- a/docs/src/markdown/selectors.md
+++ b/docs/src/markdown/selectors.md
@@ -1369,7 +1369,7 @@ Level 4 CSS<span class="lab badge"></span>
     match all of `de-DE`, `de-DE-1996`, `de-Latn-DE`, `de-Latf-DE`, and `de-Latn-DE-1996`. Implicit wildcard matching
     will not take place at the beginning on the primary language tag, `*` must be used to force wildcard matching at the
     beginning of the language. If desired an explicit wildcard between subtags can be used, but since implicit wildcard
-    matching already takes place between subtags, it is not needed: `de-*-DE` would be the as just using `de-DE`.
+    matching already takes place between subtags, it is not needed: `de-*-DE` would be the same as just using `de-DE`.
 
     ```css tab="Syntax"
     :lang('*-language', language2)

--- a/docs/src/markdown/selectors.md
+++ b/docs/src/markdown/selectors.md
@@ -1363,8 +1363,13 @@ Level 3 CSS
 
 Level 4 CSS<span class="lab badge"></span>
 : 
-    The level 4 `:lang()` adds the ability to define multiple languages, the ability to use `*` for wildcard language
-    matching.
+    The level 4 CSS specifications adds the ability to define multiple languages using a comma separated list. The
+    specifications also allow for BCP 47 language ranges as described in [RFC4647](https://tools.ietf.org/html/rfc4647)
+    for extended filtering. This enables implicit wildcard matching between subtags. For instance, `:lang(de-DE)` will
+    match all of `de-DE`, `de-DE-1996`, `de-Latn-DE`, `de-Latf-DE`, and `de-Latn-DE-1996`. Implicit wildcard matching
+    will not take place at the beginning on the primary language tag, `*` must be used to force wildcard matching at the
+    beginning of the language. If desired explicit wildcards between subtags can be used, but since implicit wildcard
+    matching already takes place between subtags, it is not needed: `de-*-DE` would be the as just using `de-DE`.
 
     ```css tab="Syntax"
     :lang('*-language', language2)

--- a/docs/src/markdown/selectors.md
+++ b/docs/src/markdown/selectors.md
@@ -1368,7 +1368,7 @@ Level 4 CSS<span class="lab badge"></span>
     for extended filtering. This enables implicit wildcard matching between subtags. For instance, `:lang(de-DE)` will
     match all of `de-DE`, `de-DE-1996`, `de-Latn-DE`, `de-Latf-DE`, and `de-Latn-DE-1996`. Implicit wildcard matching
     will not take place at the beginning on the primary language tag, `*` must be used to force wildcard matching at the
-    beginning of the language. If desired explicit wildcards between subtags can be used, but since implicit wildcard
+    beginning of the language. If desired an explicit wildcard between subtags can be used, but since implicit wildcard
     matching already takes place between subtags, it is not needed: `de-*-DE` would be the as just using `de-DE`.
 
     ```css tab="Syntax"

--- a/soupsieve/__meta__.py
+++ b/soupsieve/__meta__.py
@@ -186,5 +186,5 @@ def parse_version(ver, pre=False):
     return Version(major, minor, micro, release, pre, post, dev)
 
 
-__version_info__ = Version(1, 9, 3, "final")
+__version_info__ = Version(1, 9, 4, ".dev")
 __version__ = __version_info__._get_canonical()

--- a/soupsieve/css_parser.py
+++ b/soupsieve/css_parser.py
@@ -845,15 +845,22 @@ class CSSParser(object):
             else:
                 parts = css_unescape(value).split('-')
 
-            new_parts = []
-            first = True
+            stars = 0
             for part in parts:
-                if part == '*' and first:
-                    new_parts.append('(?!x\b)[a-z0-9]+?')
-                elif part != '*':
-                    new_parts.append(('' if first else '(-(?!x\b)[a-z0-9]+)*?\\-') + re.escape(part))
-                if first:
-                    first = False
+                if part == '*':
+                    stars += 1
+                else:
+                    break
+
+            new_parts = []
+            if stars:
+                parts = parts[stars:]
+                new_parts.append(r'.+?' if not parts else r'(?:(?:(?!x\b)[a-z0-9]+)(?:-(?!x\b)[a-z0-9]+)*?-)?')
+
+            for index, part in enumerate(parts):
+                if part != '*':
+                    new_parts.append(('' if index == 0 else r'(?:-(?!x\b)[a-z0-9]+)*?-') + re.escape(part))
+
             patterns.append(re.compile(r'^{}(?:-.*)?$'.format(''.join(new_parts)), re.I))
         sel.lang.append(ct.SelectorLang(patterns))
         has_selector = True

--- a/tests/test_level4/test_lang.py
+++ b/tests/test_level4/test_lang.py
@@ -47,6 +47,36 @@ class TestLang(util.TestCase):
             flags=util.HTML
         )
 
+    def test_only_wildcard(self):
+        """Test language with only a wildcard."""
+
+        self.assert_selector(
+            self.MARKUP,
+            "p:lang('*')",
+            ['1', '2', '3', '4', '5', '6'],
+            flags=util.HTML
+        )
+
+    def test_wildcard_start_no_match(self):
+        """Test language with a wildcard at start, but it matches nothing."""
+
+        self.assert_selector(
+            self.MARKUP,
+            "p:lang('*-de-DE')",
+            ['1', '2', '3', '4', '5', '6'],
+            flags=util.HTML
+        )
+
+    def test_wildcard_start_collapse(self):
+        """Test that language with multiple wildcards at start collapse."""
+
+        self.assert_selector(
+            self.MARKUP,
+            "p:lang('*-*-*-de-DE')",
+            ['1', '2', '3', '4', '5', '6'],
+            flags=util.HTML
+        )
+
     def test_wildcard_at_start_escaped(self):
         """
         Test language with wildcard at start (escaped).

--- a/tests/test_level4/test_lang.py
+++ b/tests/test_level4/test_lang.py
@@ -68,7 +68,7 @@ class TestLang(util.TestCase):
         )
 
     def test_wildcard_start_collapse(self):
-        """Test that language with multiple wildcards at start collapse."""
+        """Test that language with multiple wildcard patterns at start collapse."""
 
         self.assert_selector(
             self.MARKUP,


### PR DESCRIPTION
Recently, it was being discussed on the csswg-drafts repo whether certain languages should be converted to canonical extlang. While I was exploring how we'd possibly go about this, I stumbled on some scenarios related to the starting wildcard in language filters that I had overlooked, and possibly misinterpreted.  I ended up trying a couple implementations in different languages, and concluded that we didn't properly handle `*-subtag` scenarios. Specifically we didn't have it properly select 0 or more matches, and instead it selected 1 or more. This has been fixed.

With that said, there is still questions whether we support `*-*-subtag` properly, or even `subtag-*-*-subtag`. The implementations I tired outside of ours handled this very different. One treated it like ours, which essentially collapses multiple consecutive `*` down to one. The other, when handling consecutive `*`, seems to create a scenario where then for every leading `*`, one subtag must be matched. This seems to be a weird corner case as they don't seem to test for this behavior, so I opted to keep ours the same as it has been in this regard.

On a side note, I believe the csswg-drafts is discussing converting/canonizing of both the user pattern, and the HTML language attribute which makes no sense.  It is easy to translate something like `zh-yue` to `yue`, but what do you do with `*-yue` or `zh-*`, do both match `yue`?  And if so, how do you determine this? I personally think it is a bad idea to implement canonical extlang for the user pattern, but I think it is okay for the HTML content. But either way, we are not implementing that here.