### PR TITLE
Use consistent lower logic in all places

### DIFF
--- a/soupsieve/css_match.py
+++ b/soupsieve/css_match.py
@@ -1182,7 +1182,7 @@ class _Match(object):
 
         out_of_range = False
 
-        itype = self.get_attribute_by_name(el, 'type').lower()
+        itype = util.lower(self.get_attribute_by_name(el, 'type'))
         mn = self.get_attribute_by_name(el, 'min', None)
         if mn is not None:
             mn = Inputs.parse_value(itype, mn)


### PR DESCRIPTION
Case insensitive logic, in relation to CSS or HTML, usually refers to ASCII range of printable characters. CSS tokens, HTML tag names, attribute names, etc. Ensure that we use that logic in all places where appropriate.

In this case that we are fixing, while the case logic is changed, the matching results will remain unchanged. It is ensuring consistency throughout the code as there is currently no issue in the end results.