### PR TITLE
Fix option related issues in pseudo-classes :checked and :disabled

### DIFF
--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -2,6 +2,9 @@
 
 ## 1.9.4
 
+- **FIX**: `:checked` does not require an `option` element to be a child of a `select` element for it to match.
+- **FIX**: `:disabled` should only select `option` elements under a disabled `optgroup` if that `optgroup` is the
+closest parent.
 - **FIX**: Fix `:lang()` wildcard matching when applied to the primary language tag (i.e. `:lang('*-US')`). When a
 wildcard is applied at the start of the pattern, it should match zero or more, not one or more.
 

--- a/soupsieve/__meta__.py
+++ b/soupsieve/__meta__.py
@@ -186,5 +186,5 @@ def parse_version(ver, pre=False):
     return Version(major, minor, micro, release, pre, post, dev)
 
 
-__version_info__ = Version(1, 9, 4, ".dev")
+__version_info__ = Version(1, 9, 4, "final")
 __version__ = __version_info__._get_canonical()

--- a/soupsieve/css_match.py
+++ b/soupsieve/css_match.py
@@ -1237,6 +1237,24 @@ class _Match(object):
             self.get_prefix(el) is not None
         )
 
+    def match_disabled(self, el):
+        """
+        Match disabled.
+
+        - Non-option elements are not evaluated here.
+        - `options` elements will be verified to that their closest `optgroup`
+          parent is disabled.
+
+        """
+
+        match = False
+        parent = self.get_parent(el)
+        while self.get_tag(parent) != 'optgroup':
+            parent = self.get_parent(parent)
+        if self.get_attribute_by_name(parent, 'disabled') is not None:
+            match = True
+        return match
+
     def match_selectors(self, el, selectors):
         """Check if element matches one of the selectors."""
 
@@ -1268,6 +1286,9 @@ class _Match(object):
                     continue
                 # Verify element is scope
                 if selector.flags & ct.SEL_SCOPE and not self.match_scope(el):
+                    continue
+                # Verify element is disabled
+                if selector.flags & ct.SEL_DISABLED and not self.match_disabled(el):
                     continue
                 # Verify `nth` matches
                 if not self.match_nth(el, selector.nth):

--- a/soupsieve/css_types.py
+++ b/soupsieve/css_types.py
@@ -26,6 +26,7 @@ SEL_DIR_RTL = 0x40
 SEL_IN_RANGE = 0x80
 SEL_OUT_OF_RANGE = 0x100
 SEL_DEFINED = 0x200
+SEL_DISABLED = 0x400
 
 
 class Immutable(object):

--- a/tests/test_level3/test_disabled.py
+++ b/tests/test_level3/test_disabled.py
@@ -143,3 +143,20 @@ class TestDisabled(util.TestCase):
             ['4', '5', '6', '7', '8', '9', 'a', 'c'],
             flags=util.PYHTML
         )
+
+    def test_disabled_with_nested_optgroup(self):
+        """Test `:disabled` only selects `option` elements whose closest `optgroup` parent is disabled."""
+
+        self.assert_selector(
+            """
+            <optgroup id="0" disabled>
+               <option id="1"></option>
+               <optgroup id="3">
+                   <option id="4"></option>
+               </optgroup>
+            </optgroup>
+            """,
+            ":disabled",
+            ['0', '1'],
+            flags=util.HTML
+        )


### PR DESCRIPTION
Fix option element related issues in pseudo-classes `:checked` and `:disabled`

- Nothing in the level 4 specifications mentions that `option` elements have to be a child of `select` when they are considered for `:checked`.
- Also, `:disabled`, when applied to `optgroup`, is only supposed to affect the options directly under itself. If you had nested `optgroup` elements, the `option` elements should only be disabled if its closest parent is `disabled`. Grandparents `optgroups` should have no effect.
