### PR TITLE
Revert :disabled change

### DIFF
--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -2,9 +2,8 @@
 
 ## 1.9.4
 
-- **FIX**: `:checked` does not require an `option` element to be a child of a `select` element for it to match.
-- **FIX**: `:disabled` should only select `option` elements under a disabled `optgroup` if that `optgroup` is the
-closest parent.
+- **FIX**: `:checked` rule was too strict with `option` elements. The specification for `:checked` does not require an
+`option` element to be under a `select` element.
 - **FIX**: Fix `:lang()` wildcard matching when applied to the primary language tag (i.e. `:lang('*-US')`). When a
 wildcard is applied at the start of the pattern, it should match zero or more, not one or more.
 

--- a/soupsieve/css_match.py
+++ b/soupsieve/css_match.py
@@ -1237,24 +1237,6 @@ class _Match(object):
             self.get_prefix(el) is not None
         )
 
-    def match_disabled(self, el):
-        """
-        Match disabled.
-
-        - Non-option elements are not evaluated here.
-        - `options` elements will be verified to that their closest `optgroup`
-          parent is disabled.
-
-        """
-
-        match = False
-        parent = self.get_parent(el)
-        while self.get_tag(parent) != 'optgroup':
-            parent = self.get_parent(parent)
-        if self.get_attribute_by_name(parent, 'disabled') is not None:
-            match = True
-        return match
-
     def match_selectors(self, el, selectors):
         """Check if element matches one of the selectors."""
 
@@ -1286,9 +1268,6 @@ class _Match(object):
                     continue
                 # Verify element is scope
                 if selector.flags & ct.SEL_SCOPE and not self.match_scope(el):
-                    continue
-                # Verify element is disabled
-                if selector.flags & ct.SEL_DISABLED and not self.match_disabled(el):
                     continue
                 # Verify `nth` matches
                 if not self.match_nth(el, selector.nth):

--- a/soupsieve/css_parser.py
+++ b/soupsieve/css_parser.py
@@ -190,7 +190,6 @@ FLG_INDETERMINATE = 0x20
 FLG_OPEN = 0x40
 FLG_IN_RANGE = 0x80
 FLG_OUT_OF_RANGE = 0x100
-FLG_DISABLED = 0x200
 
 # Maximum cached patterns to store
 _MAXCACHE = 500
@@ -894,7 +893,6 @@ class CSSParser(object):
         is_indeterminate = bool(flags & FLG_INDETERMINATE)
         is_in_range = bool(flags & FLG_IN_RANGE)
         is_out_of_range = bool(flags & FLG_OUT_OF_RANGE)
-        is_disabled = bool(flags & FLG_DISABLED)
 
         if self.debug:  # pragma: no cover
             if is_pseudo:
@@ -915,8 +913,6 @@ class CSSParser(object):
                 print('    is_in_range: True')
             if is_out_of_range:
                 print('    is_out_of_range: True')
-            if is_disabled:
-                print('    is_disabled: True')
 
         if is_relative:
             selectors.append(_Selector())
@@ -1023,8 +1019,6 @@ class CSSParser(object):
             selectors[-1].flags = ct.SEL_IN_RANGE
         if is_out_of_range:
             selectors[-1].flags = ct.SEL_OUT_OF_RANGE
-        if is_disabled:
-            selectors[-1].flags = ct.SEL_DISABLED
 
         return ct.SelectorList([s.freeze() for s in selectors], is_not, is_html)
 
@@ -1120,16 +1114,12 @@ CSS_INDETERMINATE = CSSParser(
 CSS_DISABLED = CSSParser(
     '''
     html|*:is(input[type!=hidden], button, select, textarea, fieldset, optgroup, option, fieldset)[disabled],
+    html|optgroup[disabled] > html|option,
     html|fieldset[disabled] > html|*:is(input[type!=hidden], button, select, textarea, fieldset),
     html|fieldset[disabled] >
-        html|*:not(legend:nth-of-type(1)) html|*:is(input[type!=hidden], button, select, textarea, fieldset),
-    /*
-    This pattern must be at the end.
-    Special logic is applied to the last selector.
-    */
-    html|optgroup[disabled] html|option
+        html|*:not(legend:nth-of-type(1)) html|*:is(input[type!=hidden], button, select, textarea, fieldset)
     '''
-).process_selectors(flags=FLG_PSEUDO | FLG_HTML | FLG_DISABLED)
+).process_selectors(flags=FLG_PSEUDO | FLG_HTML)
 # CSS pattern for `:enabled`
 CSS_ENABLED = CSSParser(
     '''

--- a/soupsieve/css_types.py
+++ b/soupsieve/css_types.py
@@ -26,7 +26,6 @@ SEL_DIR_RTL = 0x40
 SEL_IN_RANGE = 0x80
 SEL_OUT_OF_RANGE = 0x100
 SEL_DEFINED = 0x200
-SEL_DISABLED = 0x400
 
 
 class Immutable(object):


### PR DESCRIPTION
Browsers never let optgroup get nested as they shuffle elements around
and even strip out tags that don't belong under an optgroup if it is
under a select. For this reason, using the browser as an example is not
always the best unless the tree is also examined and rendering.

Ultimately, we don't need to go out of our way account for bad HTML, and
for the fact that the Python parsers don't quite parse exactly like a
browser, so we will continue to simply match according to the rules.