### PR TITLE
SelectorSyntaxError is now derived from Exception

### DIFF
--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.0
+
+- **NEW**: `SelectorSyntaxError` is derived from `Exception` not `SyntaxError`.
+
 ## 1.9.4
 
 - **FIX**: `:checked` rule was too strict with `option` elements. The specification for `:checked` does not require an

--- a/soupsieve/__meta__.py
+++ b/soupsieve/__meta__.py
@@ -186,5 +186,5 @@ def parse_version(ver, pre=False):
     return Version(major, minor, micro, release, pre, post, dev)
 
 
-__version_info__ = Version(1, 9, 4, "final")
+__version_info__ = Version(2, 0, 0, ".dev")
 __version__ = __version_info__._get_canonical()

--- a/soupsieve/util.py
+++ b/soupsieve/util.py
@@ -82,7 +82,7 @@ def uord(c):
     return ordinal
 
 
-class SelectorSyntaxError(SyntaxError):
+class SelectorSyntaxError(Exception):
     """Syntax error in a CSS selector."""
 
     def __init__(self, msg, pattern=None, index=None):


### PR DESCRIPTION
SyntaxError is really used for Python syntax errors. We should not
confuse our selector syntax errors with Python syntax errors.