### PR TITLE
Experimental: Regex selectors

### DIFF
--- a/docs/src/dictionary/en-custom.txt
+++ b/docs/src/dictionary/en-custom.txt
@@ -61,6 +61,7 @@ prerelease
 prereleases
 pytest
 regex
+regex
 sublicense
 substring
 subtag

--- a/soupsieve/__init__.py
+++ b/soupsieve/__init__.py
@@ -29,10 +29,10 @@ from .__meta__ import __version__, __version_info__  # noqa: F401
 from . import css_parser as cp
 from . import css_match as cm
 from . import css_types as ct
-from .util import DEBUG, REGEX, SelectorSyntaxError  # noqa: F401
+from .util import DEBUG, RE, SelectorSyntaxError  # noqa: F401
 
 __all__ = (
-    'DEBUG', 'REGEX', 'SelectorSyntaxError', 'SoupSieve',
+    'DEBUG', 'RE', 'SelectorSyntaxError', 'SoupSieve',
     'closest', 'compile', 'filter', 'iselect',
     'match', 'select', 'select_one'
 )

--- a/soupsieve/__init__.py
+++ b/soupsieve/__init__.py
@@ -29,10 +29,10 @@ from .__meta__ import __version__, __version_info__  # noqa: F401
 from . import css_parser as cp
 from . import css_match as cm
 from . import css_types as ct
-from .util import DEBUG, SelectorSyntaxError  # noqa: F401
+from .util import DEBUG, REGEX, SelectorSyntaxError  # noqa: F401
 
 __all__ = (
-    'DEBUG', 'SelectorSyntaxError', 'SoupSieve',
+    'DEBUG', 'REGEX', 'SelectorSyntaxError', 'SoupSieve',
     'closest', 'compile', 'filter', 'iselect',
     'match', 'select', 'select_one'
 )

--- a/soupsieve/css_match.py
+++ b/soupsieve/css_match.py
@@ -662,7 +662,7 @@ class _Match(object):
                     continue
 
                 values.append((v, a.xml_type_pattern if not html_type and a.xml_type_pattern else a.pattern))
-                if not ns_string or not attr_string:
+                if not ns_string or not attr_string:  # pragma: no cover
                     continue
                 break
         else:
@@ -738,7 +738,7 @@ class _Match(object):
                     if pattern is None:
                         found = True
                         break
-                    elif pattern.match(value) is None:
+                    elif pattern.fullmatch(value) is None:
                         continue
                     else:
                         found = True

--- a/soupsieve/css_match.py
+++ b/soupsieve/css_match.py
@@ -769,8 +769,13 @@ class _Match(object):
         """Match element's ID."""
 
         found = True
+        tag_id = self.get_attribute_by_name(el, 'id', '')
         for i in ids:
-            if i != self.get_attribute_by_name(el, 'id', ''):
+            if isinstance(i, str):
+                if i != tag_id:
+                    found = False
+                    break
+            elif i.fullmatch(tag_id) is None:
                 found = False
                 break
         return found
@@ -781,9 +786,19 @@ class _Match(object):
         current_classes = self.get_classes(el)
         found = True
         for c in classes:
-            if c not in current_classes:
-                found = False
-                break
+            if isinstance(c, str):
+                if c not in current_classes:
+                    found = False
+                    break
+            else:
+                matched = False
+                for current in current_classes:
+                    if c.fullmatch(current):
+                        matched = True
+                        break
+                if not matched:
+                    found = False
+                    break
         return found
 
     def match_root(self, el):

--- a/soupsieve/css_match.py
+++ b/soupsieve/css_match.py
@@ -957,8 +957,12 @@ class _Match(object):
             if content is None:
                 content = self.get_text(el, no_iframe=self.is_html)
             found = False
-            for text in contain_list.text:
-                if text in content:
+            for contain in contain_list.contain:
+                if isinstance(contain, str):
+                    if contain in content:
+                        found = True
+                        break
+                elif contain.search(content):
                     found = True
                     break
             if not found:

--- a/soupsieve/css_match.py
+++ b/soupsieve/css_match.py
@@ -657,7 +657,7 @@ class _Match(object):
                     continue
                 elif (
                     not attr_string and
-                    (attr.fullmatch(util.lower(name)) if not self.is_xml else attr.fullmatch(name) is not None)
+                    (attr.fullmatch(util.lower(name)) is None if not self.is_xml else attr.fullmatch(name) is None)
                 ):
                     continue
 
@@ -735,9 +735,7 @@ class _Match(object):
                 for value, pattern in values:
                     if isinstance(value, list):
                         value = ' '.join(value)
-                    if value is None:
-                        continue
-                    elif pattern is None:
+                    if pattern is None:
                         found = True
                         break
                     elif pattern.match(value) is None:

--- a/soupsieve/css_parser.py
+++ b/soupsieve/css_parser.py
@@ -120,8 +120,10 @@ ATTR = r'''
 # Selector patterns
 # IDs (`#id`)
 PAT_ID = r'\#{ident}'.format(ident=IDENTIFIER)
+PAT_ID_REGEX = r'\#(?:{ident}|{regex})'.format(ident=IDENTIFIER, regex=REGEXP_IDENTIFIER)
 # Classes (`.class`)
 PAT_CLASS = r'\.{ident}'.format(ident=IDENTIFIER)
+PAT_CLASS_REGEX = r'\.(?:{ident}|{regex})'.format(ident=IDENTIFIER, regex=REGEXP_IDENTIFIER)
 # Prefix:Tag (`prefix|tag`)
 PAT_TAG = r'(?P<tag_ns>(?:{ident}|\*)?\|)?(?P<tag_name>{ident}|\*)'.format(ident=IDENTIFIER)
 # Attributes (`[attr]`, `[attr=value]`, etc.)
@@ -442,8 +444,8 @@ class CSSParser(object):
         SelectorPattern("pseudo_class", PAT_PSEUDO_CLASS),
         SelectorPattern("pseudo_element", PAT_PSEUDO_ELEMENT),
         SelectorPattern("at_rule", PAT_AT_RULE),
-        SelectorPattern("id", PAT_ID),
-        SelectorPattern("class", PAT_CLASS),
+        SelectorPattern("id", PAT_ID_REGEX),
+        SelectorPattern("class", PAT_CLASS_REGEX),
         SelectorPattern("tag", PAT_TAG),
         SelectorPattern("attribute", PAT_ATTR),
         SelectorPattern("combine", PAT_COMBINE)
@@ -805,9 +807,15 @@ class CSSParser(object):
 
         selector = m.group(0)
         if selector.startswith('.'):
-            sel.classes.append(css_unescape(selector[1:]))
+            if selector[1] == '/':
+                sel.classes.append(re.compile(selector[2:-1]))
+            else:
+                sel.classes.append(css_unescape(selector[1:]))
         else:
-            sel.ids.append(css_unescape(selector[1:]))
+            if selector[1] == '/':
+                sel.ids.append(re.compile(selector[2:-1]))
+            else:
+                sel.ids.append(css_unescape(selector[1:]))
         has_selector = True
         return has_selector
 

--- a/soupsieve/css_parser.py
+++ b/soupsieve/css_parser.py
@@ -351,7 +351,7 @@ class SelectorRegexPattern(object):
     def match(self, selector, index, flags):
         """Match the selector."""
 
-        use_regex = flags & util.REGEX
+        use_regex = flags & util.RE
         return self.re_pattern_regex.match(selector, index) if use_regex else self.re_pattern.match(selector, index)
 
 

--- a/soupsieve/css_types.py
+++ b/soupsieve/css_types.py
@@ -239,13 +239,13 @@ class SelectorAttribute(Immutable):
 class SelectorContains(Immutable):
     """Selector contains rule."""
 
-    __slots__ = ("text", "_hash")
+    __slots__ = ("contain", "_hash")
 
-    def __init__(self, text):
+    def __init__(self, contain):
         """Initialize."""
 
         super(SelectorContains, self).__init__(
-            text=text
+            contain=contain
         )
 
 

--- a/soupsieve/util.py
+++ b/soupsieve/util.py
@@ -6,6 +6,7 @@ import re
 MODULE = os.path.dirname(__file__)
 
 DEBUG = 0x00001
+REGEX = 0x00002
 
 RE_PATTERN_LINE_SPLIT = re.compile(r'(?:\r\n|(?!\r\n)[\n\r])|$')
 

--- a/soupsieve/util.py
+++ b/soupsieve/util.py
@@ -6,7 +6,7 @@ import re
 MODULE = os.path.dirname(__file__)
 
 DEBUG = 0x00001
-REGEX = 0x00002
+RE = 0x00002
 
 RE_PATTERN_LINE_SPLIT = re.compile(r'(?:\r\n|(?!\r\n)[\n\r])|$')
 

--- a/tests/test_extra/test_regex.py
+++ b/tests/test_extra/test_regex.py
@@ -188,7 +188,6 @@ class TestClass(util.TestCase):
             flags=util.HTML
         )
 
-
     def test_multiple_classes(self):
         """Test multiple classes."""
 
@@ -226,7 +225,115 @@ class TestId(util.TestCase):
 
         self.assert_selector(
             self.MARKUP,
-            "#/u.*/",
+            r"#/u.*/",
             ["unique"],
             flags=util.HTML
+        )
+
+
+class TestRegexType(util.TestCase):
+    """Test type selectors with regex."""
+
+    def test_basic_type(self):
+        """Test type."""
+
+        self.assert_selector(
+            """
+            <html>
+            <head></head>
+            <body>
+            <div>
+            <p>Some text <span id="1"> in a paragraph</span>.</p>
+            <a id="2" href="http://google.com">Link</a>
+            </div>
+            </body>
+            </html>
+            """,
+            r"body /.*?a.*/",
+            ["1", "2"],
+            flags=util.HTML
+        )
+
+
+class TestNamespace(util.TestCase):
+    """Test namespace selectors."""
+
+    MARKUP = """
+    <?xml version="1.0" encoding="UTF-8"?>
+    <tag id="root">
+      <head id="0"></head>
+      <foo:other id="1" xmlns:foo="http://me.com/namespaces/foofoo"
+             xmlns:bar="http://me.com/namespaces/foobar">
+      <foo:head id="2">
+        <foo:title id="3"></foo:title>
+        <bar:title id="4"></bar:title>
+      </foo:head>
+      <body id="5">
+        <foo:e1 id="6"></foo:e1>
+        <bar:e1 id="7"></bar:e1>
+        <e1 id="8"></e1>
+        <foo:e2 id="9"></foo:e2>
+        <bar:e2 id="10"></bar:e2>
+        <e2 id="11"></e2>
+        <foo:e3 id="12"></foo:e3>
+        <bar:e3 id="13"></bar:e3>
+        <e3 id="14"></e3>
+      </body>
+      </foo:other>
+      <other id="15" xmlns="http://me.com/namespaces/other">
+        <e4 id="16">Inherit</er>
+      </other>
+    </tag>
+    """
+
+    def test_namespace_regex(self):
+        """Test namespace."""
+
+        self.assert_selector(
+            self.MARKUP,
+            r"/fo{2}/|title",
+            ["3"],
+            namespaces={
+                "foo": "http://me.com/namespaces/foofoo",
+                "bar": "http://me.com/namespaces/foobar"
+            },
+            flags=util.XML
+        )
+
+        self.assert_selector(
+            self.MARKUP,
+            r"/(?:foo|bar)/|title",
+            ["3", "4"],
+            namespaces={
+                "foo": "http://me.com/namespaces/foofoo",
+                "bar": "http://me.com/namespaces/foobar"
+            },
+            flags=util.XML
+        )
+
+    def test_namespace_case_regex(self):
+        """Test that namespaces are always case sensitive."""
+
+        # These won't match
+        self.assert_selector(
+            self.MARKUP,
+            r"/FO{2}/|title",
+            [],
+            namespaces={
+                "foo": "http://me.com/namespaces/foofoo",
+                "bar": "http://me.com/namespaces/foobar"
+            },
+            flags=util.XML
+        )
+
+        # These won't match
+        self.assert_selector(
+            self.MARKUP,
+            r"/(?i)FO{2}/|title",
+            ["3"],
+            namespaces={
+                "foo": "http://me.com/namespaces/foofoo",
+                "bar": "http://me.com/namespaces/foobar"
+            },
+            flags=util.XML
         )

--- a/tests/test_extra/test_regex.py
+++ b/tests/test_extra/test_regex.py
@@ -138,6 +138,16 @@ class TestRegexAttribute(util.TestCase):
             flags=util.HTML
         )
 
+    def test_attribute_start_dash_regex_case(self):
+        """Test attribute whose dash separated value starts with the specified value with case insensitivity."""
+
+        self.assert_regex_selector(
+            self.MARKUP_LANG,
+            r"[lang|=/(?i)E./]",
+            ["0"],
+            flags=util.HTML
+        )
+
     def test_attribute_start_dash_regex_fail(self):
         """Test attribute whose dash separated value starts with the specified value."""
 

--- a/tests/test_extra/test_regex.py
+++ b/tests/test_extra/test_regex.py
@@ -165,3 +165,68 @@ class TestRegexAttribute(util.TestCase):
             ["0"],
             flags=util.HTML
         )
+
+
+class TestClass(util.TestCase):
+    """Test class selectors."""
+
+    MARKUP = """
+    <div>
+    <p>Some text <span id="1" class="foo"> in a paragraph</span>.
+    <a id="2" class="bar" href="http://google.com">Link</a>
+    </p>
+    </div>
+    """
+
+    def test_class(self):
+        """Test class."""
+
+        self.assert_selector(
+            self.MARKUP,
+            r"./fo{2}/",
+            ["1"],
+            flags=util.HTML
+        )
+
+
+    def test_multiple_classes(self):
+        """Test multiple classes."""
+
+        markup = """
+        <div>
+        <p>Some text <span id="1" class="foo"> in a paragraph</span>.
+        <a id="2" class="bar" href="http://google.com">Link</a>
+        <a id="3" class="foo" href="http://google.com">Link</a>
+        <a id="4" class="foo bar" href="http://google.com">Link</a>
+        </p>
+        </div>
+        """
+
+        self.assert_selector(
+            markup,
+            "a./fo{2}/./b.*/",
+            ["4"],
+            flags=util.HTML
+        )
+
+
+class TestId(util.TestCase):
+    """Test ID selectors."""
+
+    MARKUP = """
+    <div>
+    <p>Some text <span id="unique"> in a paragraph</span>.
+    <a id="2" href="http://google.com">Link</a>
+    </p>
+    </div>
+    """
+
+    def test_id(self):
+        """Test ID."""
+
+        self.assert_selector(
+            self.MARKUP,
+            "#/u.*/",
+            ["unique"],
+            flags=util.HTML
+        )

--- a/tests/test_extra/test_regex.py
+++ b/tests/test_extra/test_regex.py
@@ -18,7 +18,7 @@ class TestRegexContains(util.TestCase):
     def test_contains_regex(self):
         """Test contains with regex."""
 
-        self.assert_selector(
+        self.assert_regex_selector(
             self.MARKUP,
             r'body span:contains(/t\w+/)',
             ['2'],
@@ -28,7 +28,7 @@ class TestRegexContains(util.TestCase):
     def test_contains_regex_no_match(self):
         """Test contains that does not match regex."""
 
-        self.assert_selector(
+        self.assert_regex_selector(
             self.MARKUP,
             r'body span:contains(/T\w+/)',
             [],
@@ -38,7 +38,7 @@ class TestRegexContains(util.TestCase):
     def test_contains_regex_flags(self):
         """Test contains using regex flags."""
 
-        self.assert_selector(
+        self.assert_regex_selector(
             self.MARKUP,
             r'body span:contains(/(?i)T\w+/)',
             ['2'],
@@ -78,7 +78,7 @@ class TestRegexAttribute(util.TestCase):
     def test_attribute_begins_regex(self):
         """Test attribute whose value begins with the specified value."""
 
-        self.assert_selector(
+        self.assert_regex_selector(
             self.MARKUP,
             r"[class^=/h[e]re/]",
             ["0"],
@@ -88,7 +88,7 @@ class TestRegexAttribute(util.TestCase):
     def test_attribute_end_regex(self):
         """Test attribute whose value ends with the specified value."""
 
-        self.assert_selector(
+        self.assert_regex_selector(
             self.MARKUP,
             r"[class$=/w[or]+ds/]",
             ["0"],
@@ -111,7 +111,7 @@ class TestRegexAttribute(util.TestCase):
         </div>
         """
 
-        self.assert_selector(
+        self.assert_regex_selector(
             markup,
             r"[class*=/w[or]+ds/]",
             ["0", "3", "pre"],
@@ -121,7 +121,7 @@ class TestRegexAttribute(util.TestCase):
     def test_attribute_equal_regex(self):
         """Test attribute equals a value."""
 
-        self.assert_selector(
+        self.assert_regex_selector(
             self.MARKUP_LANG,
             r"[lang=/e.*?s/]",
             ["0"],
@@ -131,7 +131,7 @@ class TestRegexAttribute(util.TestCase):
     def test_attribute_start_dash_regex(self):
         """Test attribute whose dash separated value starts with the specified value."""
 
-        self.assert_selector(
+        self.assert_regex_selector(
             self.MARKUP_LANG,
             r"[lang|=/e./]",
             ["0"],
@@ -141,7 +141,7 @@ class TestRegexAttribute(util.TestCase):
     def test_attribute_start_dash_regex_fail(self):
         """Test attribute whose dash separated value starts with the specified value."""
 
-        self.assert_selector(
+        self.assert_regex_selector(
             self.MARKUP_LANG,
             r"[lang|=/E./]",
             [],
@@ -151,7 +151,7 @@ class TestRegexAttribute(util.TestCase):
     def test_attribute_start_dash_regex_flags(self):
         """Test attribute whose dash separated value starts with the specified value."""
 
-        self.assert_selector(
+        self.assert_regex_selector(
             self.MARKUP_LANG,
             r"[lang|=/(?i)E./]",
             ["0"],
@@ -159,7 +159,7 @@ class TestRegexAttribute(util.TestCase):
         )
 
         # Attribute style case selection
-        self.assert_selector(
+        self.assert_regex_selector(
             self.MARKUP_LANG,
             r"[lang|=/E./ i]",
             ["0"],
@@ -181,7 +181,7 @@ class TestRegexClass(util.TestCase):
     def test_class(self):
         """Test class."""
 
-        self.assert_selector(
+        self.assert_regex_selector(
             self.MARKUP,
             r"./fo{2}/",
             ["1"],
@@ -201,7 +201,7 @@ class TestRegexClass(util.TestCase):
         </div>
         """
 
-        self.assert_selector(
+        self.assert_regex_selector(
             markup,
             "a./fo{2}/./b.*/",
             ["4"],
@@ -223,7 +223,7 @@ class TestRegexId(util.TestCase):
     def test_id(self):
         """Test ID."""
 
-        self.assert_selector(
+        self.assert_regex_selector(
             self.MARKUP,
             r"#/u.*/",
             ["unique"],
@@ -237,7 +237,7 @@ class TestRegexType(util.TestCase):
     def test_basic_type(self):
         """Test type."""
 
-        self.assert_selector(
+        self.assert_regex_selector(
             """
             <html>
             <head></head>
@@ -331,7 +331,7 @@ class TestRegexNamespace(util.TestCase):
     def test_namespace_regex(self):
         """Test namespace."""
 
-        self.assert_selector(
+        self.assert_regex_selector(
             self.MARKUP,
             r"/fo{2}/|title",
             ["3"],
@@ -342,7 +342,7 @@ class TestRegexNamespace(util.TestCase):
             flags=util.XML
         )
 
-        self.assert_selector(
+        self.assert_regex_selector(
             self.MARKUP,
             r"/(?:foo|bar)/|title",
             ["3", "4"],
@@ -357,7 +357,7 @@ class TestRegexNamespace(util.TestCase):
         """Test that namespaces are always case sensitive."""
 
         # These won't match
-        self.assert_selector(
+        self.assert_regex_selector(
             self.MARKUP,
             r"/FO{2}/|title",
             [],
@@ -369,7 +369,7 @@ class TestRegexNamespace(util.TestCase):
         )
 
         # These won't match
-        self.assert_selector(
+        self.assert_regex_selector(
             self.MARKUP,
             r"/(?i)FO{2}/|title",
             ["3"],
@@ -383,7 +383,7 @@ class TestRegexNamespace(util.TestCase):
     def test_attribute_namespace_xml(self):
         """Test attribute namespace in XML."""
 
-        self.assert_selector(
+        self.assert_regex_selector(
             self.wrap_xlink(self.MARKUP_ATTR),
             r'[/x.*/|href*=forw],[/x.*/|href="images/sprites.svg#icon-redo"]',
             ['1', '2'],
@@ -411,7 +411,7 @@ class TestRegexAttributeName(util.TestCase):
     def test_attribute_begins(self):
         """Test attribute whose value begins with the specified value."""
 
-        self.assert_selector(
+        self.assert_regex_selector(
             self.MARKUP,
             r"[/clas{2}/^=here]",
             ["0"],
@@ -421,7 +421,7 @@ class TestRegexAttributeName(util.TestCase):
     def test_attribute_begins_wild(self):
         """Test attribute whose value begins with the specified value."""
 
-        self.assert_selector(
+        self.assert_regex_selector(
             self.MARKUP,
             r"[/.*/^=here]",
             ["0"],

--- a/tests/test_extra/test_regex.py
+++ b/tests/test_extra/test_regex.py
@@ -391,6 +391,17 @@ class TestRegexNamespace(util.TestCase):
             flags=util.XHTML
         )
 
+    def test_attribute_namespace_xml_no_match(self):
+        """Test attribute namespace in XML."""
+
+        self.assert_regex_selector(
+            self.wrap_xlink(self.MARKUP_ATTR),
+            r'[/x.*/|/nomatch/*=forw]',
+            [],
+            namespaces={"xlink": "http://www.w3.org/1999/xlink"},
+            flags=util.XHTML
+        )
+
 
 class TestRegexAttributeName(util.TestCase):
     """Test attribute selectors."""

--- a/tests/test_extra/test_regex.py
+++ b/tests/test_extra/test_regex.py
@@ -1,0 +1,167 @@
+"""Test contains selectors."""
+from .. import util
+
+
+class TestRegexContains(util.TestCase):
+    """Test regex contains selectors."""
+
+    MARKUP = """
+    <body>
+    <div id="1">
+    Testing
+    <span id="2"> that </span>
+    contains works.
+    </div>
+    </body>
+    """
+
+    def test_contains_regex(self):
+        """Test contains with regex."""
+
+        self.assert_selector(
+            self.MARKUP,
+            r'body span:contains(/t\w+/)',
+            ['2'],
+            flags=util.HTML
+        )
+
+    def test_contains_regex_no_match(self):
+        """Test contains that does not match regex."""
+
+        self.assert_selector(
+            self.MARKUP,
+            r'body span:contains(/T\w+/)',
+            [],
+            flags=util.HTML
+        )
+
+    def test_contains_regex_flags(self):
+        """Test contains using regex flags."""
+
+        self.assert_selector(
+            self.MARKUP,
+            r'body span:contains(/(?i)T\w+/)',
+            ['2'],
+            flags=util.HTML
+        )
+
+
+class TestRegexAttribute(util.TestCase):
+    """Test regex attribute selectors."""
+
+    MARKUP = """
+    <div id="div">
+    <p id="0" class="herearesomewords">Some text <span id="1"> in a paragraph</span>.</p>
+    <a id="2" href="http://google.com">Link</a>
+    <span id="3">Direct child</span>
+    <pre id="pre">
+    <span id="4">Child 1</span>
+    <span id="5">Child 2</span>
+    <span id="6">Child 3</span>
+    </pre>
+    </div>
+    """
+
+    MARKUP_LANG = """
+    <div id="div">
+    <p id="0" lang="en-us">Some text <span id="1"> in a paragraph</span>.</p>
+    <a id="2" href="http://google.com">Link</a>
+    <span id="3">Direct child</span>
+    <pre id="pre">
+    <span id="4">Child 1</span>
+    <span id="5">Child 2</span>
+    <span id="6">Child 3</span>
+    </pre>
+    </div>
+    """
+
+    def test_attribute_begins_regex(self):
+        """Test attribute whose value begins with the specified value."""
+
+        self.assert_selector(
+            self.MARKUP,
+            r"[class^=/h[e]re/]",
+            ["0"],
+            flags=util.HTML
+        )
+
+    def test_attribute_end_regex(self):
+        """Test attribute whose value ends with the specified value."""
+
+        self.assert_selector(
+            self.MARKUP,
+            r"[class$=/w[or]+ds/]",
+            ["0"],
+            flags=util.HTML
+        )
+
+    def test_attribute_contains_regex(self):
+        """Test attribute whose value contains the specified value."""
+
+        markup = """
+        <div id="div">
+        <p id="0" class="somewordshere">Some text <span id="1"> in a paragraph</span>.</p>
+        <a id="2" href="http://google.com">Link</a>
+        <span id="3" class="herewords">Direct child</span>
+        <pre id="pre" class="wordshere">
+        <span id="4">Child 1</span>
+        <span id="5">Child 2</span>
+        <span id="6">Child 3</span>
+        </pre>
+        </div>
+        """
+
+        self.assert_selector(
+            markup,
+            r"[class*=/w[or]+ds/]",
+            ["0", "3", "pre"],
+            flags=util.HTML
+        )
+
+    def test_attribute_equal_regex(self):
+        """Test attribute equals a value."""
+
+        self.assert_selector(
+            self.MARKUP_LANG,
+            r"[lang=/e.*?s/]",
+            ["0"],
+            flags=util.HTML
+        )
+
+    def test_attribute_start_dash_regex(self):
+        """Test attribute whose dash separated value starts with the specified value."""
+
+        self.assert_selector(
+            self.MARKUP_LANG,
+            r"[lang|=/e./]",
+            ["0"],
+            flags=util.HTML
+        )
+
+    def test_attribute_start_dash_regex_fail(self):
+        """Test attribute whose dash separated value starts with the specified value."""
+
+        self.assert_selector(
+            self.MARKUP_LANG,
+            r"[lang|=/E./]",
+            [],
+            flags=util.HTML
+        )
+
+    def test_attribute_start_dash_regex_flags(self):
+        """Test attribute whose dash separated value starts with the specified value."""
+
+        self.assert_selector(
+            self.MARKUP_LANG,
+            r"[lang|=/(?i)E./]",
+            ["0"],
+            flags=util.HTML
+        )
+
+        # Attribute style case selection
+        self.assert_selector(
+            self.MARKUP_LANG,
+            r"[lang|=/E./ i]",
+            ["0"],
+            flags=util.HTML
+        )

--- a/tests/util.py
+++ b/tests/util.py
@@ -121,6 +121,24 @@ class TestCase(unittest.TestCase):
                 ids.append(el.attrs['id'])
             self.assertEqual(sorted(ids), sorted(expected_ids))
 
+    def assert_regex_selector(self, markup, selectors, expected_ids, namespaces={}, custom=None, flags=0):
+        """Assert selector."""
+
+        parsers = self.get_parsers(flags)
+
+        print('----Running Selector Test----')
+        selector = self.compile_pattern(selectors, namespaces, custom, sv.REGEX)
+
+        for parser in available_parsers(*parsers):
+            soup = self.soup(markup, parser)
+            # print(soup)
+
+            ids = []
+            for el in selector.select(soup):
+                print('TAG: ', el.name)
+                ids.append(el.attrs['id'])
+            self.assertEqual(sorted(ids), sorted(expected_ids))
+
 
 def available_parsers(*parsers):
     """Filter a list of parsers, down to the available ones.

--- a/tests/util.py
+++ b/tests/util.py
@@ -127,7 +127,7 @@ class TestCase(unittest.TestCase):
         parsers = self.get_parsers(flags)
 
         print('----Running Selector Test----')
-        selector = self.compile_pattern(selectors, namespaces, custom, sv.REGEX)
+        selector = self.compile_pattern(selectors, namespaces, custom, sv.RE)
 
         for parser in available_parsers(*parsers):
             soup = self.soup(markup, parser)


### PR DESCRIPTION
Experimental custom regex selectors. Not guaranteed to be merged. This is mainly a test to see how useful and practical a feature like this might be.

Regex selectors are denoted between forward slashes: `/.../`. They can be used in place of namespace selectors, type selectors, attribute name, attribute value, and as the content of `:contains()`.

Traditional CSS escapes do not currently apply to regex selectors, but instead default to Python regular expression escapes.

By default, like regex in general, it is case sensitive, but you can add the flag `(?i)` to enable insensitive functionality: `/(?i)somepattern/`. When using in HTML, it is important to remember that tags and attribute names are evaluated as lower case.  Attribute values are evaluated as case sensitive by default unless they are associated with a `type` attribute, in which case they will be evaluated as case insensitive. Regex selectors are also forced into case insensitivity if they are evaluated with the attribute `i` option: `[attr=/valueregex/ i]`.

Regex selectors, since this is experimental, are disabled by default, but can be enabled via the `REGEX` flag: `soup.select(r'/\w+/.class', flags=soupsieve.REGEX)`.

