### PR TITLE
Remove unused variable MODULE

### DIFF
--- a/soupsieve/util.py
+++ b/soupsieve/util.py
@@ -3,7 +3,6 @@ from functools import wraps
 import warnings
 import os
 import re
-MODULE = os.path.dirname(__file__)
 
 DEBUG = 0x00001
 

--- a/soupsieve/util.py
+++ b/soupsieve/util.py
@@ -1,7 +1,6 @@
 """Utility."""
 from functools import wraps
 import warnings
-import os
 import re
 
 DEBUG = 0x00001


### PR DESCRIPTION
Fixes https://github.com/facelessuser/soupsieve/issues/184

Removing this line removes the only reference to `__file__`, which
allows tools like pyoxidizer to create standalone binaries that depend
on this package. See also:
https://github.com/indygreg/PyOxidizer/issues/69