### PR TITLE
perf: Annotate soupsieve.util.lower() with LRU cache

### DIFF
--- a/soupsieve/util.py
+++ b/soupsieve/util.py
@@ -1,5 +1,5 @@
 """Utility."""
-from functools import wraps
+from functools import wraps, lru_cache
 import warnings
 import re
 
@@ -13,6 +13,7 @@ UC_A = ord('A')
 UC_Z = ord('Z')
 
 
+@lru_cache(maxsize=512)
 def lower(string):
     """Lower."""
 


### PR DESCRIPTION
`lower()` is a hot function that seems to be usually called with a very few different parameters, so using an LRU cache makes it much more efficient. (The maxsize parameter could be tweaked, maybe?)

Closes #190