### PR TITLE
:-soup-contains-own (based on #200 by @sm-ghavami)

### DIFF
--- a/docs/src/markdown/selectors/pseudo-classes.md
+++ b/docs/src/markdown/selectors/pseudo-classes.md
@@ -80,42 +80,6 @@ Selects any `#!html <input type="radio"/>`, `#!html <input type="checkbox"/>`, o
 !!! tip "Additional Reading"
     https://developer.mozilla.org/en-US/docs/Web/CSS/:checked
 
-## `:contains()`:material-star:{: title="Custom" data-md-color-primary="green" .icon} {:#:contains}
-
-Selects elements that contain the provided text. Text can be found in either itself, or its descendants.
-
-Contains was originally included in a [CSS early draft][contains-draft], but was, in the end, dropped from the draft.
-Soup Sieve implements it how it was originally proposed in the draft with the addition that `:contains()` can accept
-either a single value, or a comma separated list of values. An element needs only to match at least one of the items
-in the comma separated list to be considered matching.
-
-!!! warning "Contains"
-    `:contains()` is an expensive operation as it scans all the text nodes of an element under consideration, which
-    includes all descendants. Using highly specific selectors can reduce how often it is evaluated.
-
-=== "Syntax"
-    ```css
-    :contains(text)
-    :contains("This text", "or this text")
-    ```
-
-=== "Usage"
-    ```pycon3
-    >>> from bs4 import BeautifulSoup as bs
-    >>> html = """
-    ... <html>
-    ... <head></head>
-    ... <body>
-    ...   <div>Here is <span>some text</span>.</div>
-    ...   <div>Here is some more text.</div>
-    ... </body>
-    ... </html>
-    ... """
-    >>> soup = bs(html, 'html5lib')
-    >>> print(soup.select('div:contains("some text")'))
-    [<div>Here is <span>some text</span>.</div>]
-    ```
-
 ## `:default`:material-language-html5:{: title="HTML" data-md-color-primary="orange" .icon}:material-flask:{: title="Experimental" data-md-color-primary="purple" .icon} {:#:default}
 
 Selects any form element that is the default among a group of related elements, including: `#!html <button>`,
@@ -807,7 +771,7 @@ Level 3 CSS
         ... </html>
         ... """
         >>> soup = bs(html, 'html5lib')
-        >>> print(soup.select('div:not(:contains(more))'))
+        >>> print(soup.select('div:not(:-soup-contains(more))'))
         [<div>Here is some text.</div>]
         ```
 
@@ -1541,6 +1505,81 @@ While the level 4 specifications state that [compound](#compound-selector) selec
 
 !!! tip "Additional Reading"
     https://developer.mozilla.org/en-US/docs/Web/CSS/:where
+
+## `:-soup-contains()`:material-star:{: title="Custom" data-md-color-primary="green" .icon} {:#:-soup-contains}
+
+Selects elements that contain the provided text. Text can be found in either itself, or its descendants.
+
+Originally, there was a pseudo-class called `:contains()` that was originally included in a [CSS early draft][contains-draft],
+but was dropped from the draft in the end. Soup Sieve implements it how it was originally proposed accept for two
+differences: it is called `:-soup-contains()` instead of `:contains()`, and it can accept either a single value, or a
+comma separated list of values. An element needs only to match at least one of the items in the comma separated list to
+be considered matching.
+
+!!! warning "Rename 2.1"
+    The name `:-soup-contains()` is new in version 2.1. Previously, it was known by `:contains()`. While the alias of
+    `:contains()` is currently allowed, this alias is deprecated moving forward and will be removed in a future version.
+    It is recommended to migrate to the name `:-soup-contains` moving forward.
+
+!!! warning "Expensive Operation"
+    `:-soup-contains()` is an expensive operation as it scans all the text nodes of an element under consideration,
+    which includes all descendants. Using highly specific selectors can reduce how often it is evaluated.
+
+=== "Syntax"
+    ```css
+    :-soup-contains(text)
+    :-soup-contains("This text", "or this text")
+    ```
+
+=== "Usage"
+    ```pycon3
+    >>> from bs4 import BeautifulSoup as bs
+    >>> html = """
+    ... <html>
+    ... <head></head>
+    ... <body>
+    ...   <div>Here is <span>some text</span>.</div>
+    ...   <div>Here is some more text.</div>
+    ... </body>
+    ... </html>
+    ... """
+    >>> soup = bs(html, 'html5lib')
+    >>> print(soup.select('div:-soup-contains("some text")'))
+    [<div>Here is <span>some text</span>.</div>]
+    ```
+
+## `:-soup-contains-own()`:material-star:{: title="Custom" data-md-color-primary="green" .icon} {:#:-soup-contains-own}
+
+Selects elements that contain the provided text. Text must be found in the target element and not in its descendants. If
+text is broken up with with descendant elements, each text node will be evaluated separately.
+
+Syntax is the same as [`:-soup-contains()`](#:-soup-contains).
+
+=== "Syntax"
+    ```css
+    :-soup-contains-own(text)
+    :-soup-contains-own("This text", "or this text")
+    ```
+
+=== "Usage"
+    ```pycon3
+    >>> from bs4 import BeautifulSoup as bs
+    >>> html = """
+    ... <html>
+    ... <head></head>
+    ... <body>
+    ...   <div>Here is <span>some text</span>.</div>
+    ...   <div>Here is some more text.</div>
+    ... </body>
+    ... </html>
+    ... """
+    >>> soup = bs(html, 'html5lib')
+    >>> print(soup.select('div:-soup-contains-own("some")'))
+    [<div>Here is some more text.</div>]
+    ```
+
+!!! new "New in 2.1"
+    `:-soup-contains-own()` was added in 2.1.
 
 --8<--
 selector_styles.txt

--- a/soupsieve/css_match.py
+++ b/soupsieve/css_match.py
@@ -316,6 +316,11 @@ class _DocumentNav(object):
             [node for node in self.get_descendants(el, tags=False, no_iframe=no_iframe) if self.is_content_string(node)]
         )
 
+    def get_own_text(self, el, no_iframe=False):
+        """Get Own Text."""
+
+        return [node for node in self.get_contents(el, no_iframe=no_iframe) if self.is_content_string(node)]
+
 
 class Inputs(object):
     """Class for parsing and validating input items."""
@@ -943,12 +948,23 @@ class _Match(object):
         content = None
         for contain_list in contains:
             if content is None:
-                content = self.get_text(el, no_iframe=self.is_html)
+                if contain_list.own:
+                    content = self.get_own_text(el, no_iframe=self.is_html)
+                else:
+                    content = self.get_text(el, no_iframe=self.is_html)
             found = False
             for text in contain_list.text:
-                if text in content:
-                    found = True
-                    break
+                if contain_list.own:
+                    for c in content:
+                        if text in c:
+                            found = True
+                            break
+                    if found:
+                        break
+                else:
+                    if text in content:
+                        found = True
+                        break
             if not found:
                 match = False
         return match

--- a/soupsieve/css_types.py
+++ b/soupsieve/css_types.py
@@ -239,13 +239,14 @@ class SelectorAttribute(Immutable):
 class SelectorContains(Immutable):
     """Selector contains rule."""
 
-    __slots__ = ("text", "_hash")
+    __slots__ = ("text", "own", "_hash")
 
-    def __init__(self, text):
+    def __init__(self, text, own):
         """Initialize."""
 
         super(SelectorContains, self).__init__(
-            text=text
+            text=text,
+            own=own
         )
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -421,7 +421,7 @@ class TestSoupSieve(util.TestCase):
         # `SelectorNth`, `SelectorLang`, `SelectorList`, `Namespaces`,
         # `SelectorContains`, and `CustomSelectors`.
         p1 = sv.compile(
-            'p.class#id[id]:nth-child(2):lang(en):focus:contains("text", "other text")',
+            'p.class#id[id]:nth-child(2):lang(en):focus:-soup-contains("text", "other text")',
             {'html': 'http://www.w3.org/TR/html4/'},
             custom={':--header': 'h1, h2, h3, h4, h5, h6'}
         )
@@ -431,7 +431,7 @@ class TestSoupSieve(util.TestCase):
 
         # Test that we pull the same one from cache
         p2 = sv.compile(
-            'p.class#id[id]:nth-child(2):lang(en):focus:contains("text", "other text")',
+            'p.class#id[id]:nth-child(2):lang(en):focus:-soup-contains("text", "other text")',
             {'html': 'http://www.w3.org/TR/html4/'},
             custom={':--header': 'h1, h2, h3, h4, h5, h6'}
         )
@@ -439,7 +439,7 @@ class TestSoupSieve(util.TestCase):
 
         # Test that we compile a new one when providing a different flags
         p3 = sv.compile(
-            'p.class#id[id]:nth-child(2):lang(en):focus:contains("text", "other text")',
+            'p.class#id[id]:nth-child(2):lang(en):focus:-soup-contains("text", "other text")',
             {'html': 'http://www.w3.org/TR/html4/'},
             custom={':--header': 'h1, h2, h3, h4, h5, h6'},
             flags=0x10

--- a/tests/test_extra/test_soup_contains_own.py
+++ b/tests/test_extra/test_soup_contains_own.py
@@ -1,0 +1,79 @@
+"""Test contains selectors."""
+from .. import util
+
+
+class TestSoupContainsOwn(util.TestCase):
+    """Test soup-contains-own selectors."""
+
+    MARKUP = """
+    <body>
+    <div id="1">
+    Testing
+    <span id="2"> that </span>
+    contains works.
+    </div>
+    </body>
+    """
+
+    def test_contains_own_descendants(self):
+        """Test contains-own won't match text if contained in descendants."""
+
+        self.assert_selector(
+            self.MARKUP,
+            'body div:-soup-contains-own(that)',
+            [],
+            flags=util.HTML
+        )
+
+    def test_contains_own(self):
+        """Test contains-own."""
+
+        self.assert_selector(
+            self.MARKUP,
+            'body *:-soup-contains-own(that)',
+            ['2'],
+            flags=util.HTML
+        )
+
+    def test_contains_own_cdata_html(self):
+        """Test contains CDATA in HTML5."""
+
+        markup = """
+        <body><div id="1">Testing that <span id="2"><![CDATA[that]]></span>contains works.</div></body>
+        """
+
+        self.assert_selector(
+            markup,
+            'body *:-soup-contains-own("that")',
+            ['1'],
+            flags=util.HTML
+        )
+
+    def test_contains_own_cdata_xml(self):
+        """Test contains-own CDATA in XML."""
+
+        markup = """
+        <div id="1">Testing that <span id="2"><![CDATA[that]]></span>contains works.</div>
+        """
+
+        self.assert_selector(
+            markup,
+            '*:-soup-contains-own("that")',
+            ['1', '2'],
+            flags=util.XML
+        )
+
+    def test_contains_own_with_broken_text(self):
+        """Test contains-own to see how it matches a broken text."""
+
+        markup = """
+        <body>
+        <div id="1"> A simple test <div id="2"> to </div> show the broken text case. </div>
+        </body>
+        """
+        self.assert_selector(
+            markup,
+            'body div:-soup-contains-own("test  show")',
+            [],
+            flags=util.HTML
+        )


### PR DESCRIPTION
- Rename :contains() to :-soup-contains().
- Allow usage of :contains() but mark it as deprecated and instruct
  users to switch over to :-soup-contains().
- Add :-soup-contains-own which is like contains, but adds the
  restriction that the text nodes must be under the element under
  evaluation.

Closes #200

This is under evaluation and may or may not be merged.