### PR TITLE
Update :any-link and :link to reflect recent level 4 CSS selector change

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,48 +36,24 @@ jobs:
         python -m mkdocs gh-deploy -v --clean --remote-name gh-token
         git push gh-token gh-pages
 
-  wheel:
+  pypi:
     strategy:
       matrix:
-        python-version: [3.9]
+        distribution: [bdist_wheel, sdist]
 
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
       - uses: actions/setup-python@v1
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: 3.9
       - name: Package
         run: |
           pip install --upgrade setuptools wheel
-          python setup.py bdist_wheel
+          python setup.py ${{ matrix.distribution }}
       - name: Publish
-        uses: pypa/gh-action-pypi-publish@v1.0.0a0
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_TOKEN }}
-
-  sdist:
-    strategy:
-      matrix:
-        python-version: [3.9]
-
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v1
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Package
-        run: |
-          pip install --upgrade setuptools
-          python setup.py sdist
-      - name: Publish
-        uses: pypa/gh-action-pypi-publish@v1.0.0a0
+        uses: pypa/gh-action-pypi-publish@v1.4.1
         with:
           user: __token__
           password: ${{ secrets.PYPI_TOKEN }}

--- a/docs/src/dictionary/en-custom.txt
+++ b/docs/src/dictionary/en-custom.txt
@@ -39,6 +39,7 @@ combinator
 combinators
 deprecations
 deregister
+dev
 directionality
 formatter
 hashable

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.2.0.dev
+
+- **NEW**: `:link` and `:any-link` no longer include `#!html <link>` due to a change in the level 4 selector
+  specification.
+
 ## 2.1.0
 
 - **NEW**: Officially support Python 3.9.

--- a/docs/src/markdown/selectors/pseudo-classes.md
+++ b/docs/src/markdown/selectors/pseudo-classes.md
@@ -10,7 +10,7 @@ implement as they might not stick around.
 
 ## `:any-link`:material-language-html5:{: title="HTML" data-md-color-primary="orange" .icon}:material-flask:{: title="Experimental" data-md-color-primary="purple" .icon} {:#:any-link}
 
-Selects every `#!html <a>`, `#!html <area>`, or `#!html <link>` element that has an `href` attribute, independent of
+Selects every `#!html <a>`, or `#!html <area>` element that has an `href` attribute, independent of
 whether it has been visited.
 
 === "Syntax"
@@ -36,6 +36,10 @@ whether it has been visited.
 
 !!! tip "Additional Reading"
     https://developer.mozilla.org/en-US/docs/Web/CSS/:any-link
+
+!!! new "New in 2.2"
+    The CSS specification recently updated to not include `#!html <link>` in the definition; therefore, Soup Sieve has
+    removed it as well.
 
 ## `:checked`:material-language-html5:{: title="HTML" data-md-color-primary="orange" .icon} {:#:checked}
 
@@ -716,7 +720,7 @@ Selects the last child of a given type in a group of sibling elements.
 
 ## `:link`:material-language-html5:{: title="HTML" data-md-color-primary="orange" .icon} {:#:link}
 
-Selects a link (every `#!html <a>`, `#!html <link>`, and `#!html <area>` element with an `href` attribute) that has not
+Selects a link (every `#!html <a>` and `#!html <area>` element with an `href` attribute) that has not
 yet been visited.
 
 Since Beautiful Soup does not have *visited* states, this will match all links, essentially making the behavior the same
@@ -729,7 +733,7 @@ as `:any-link`.
 
 === "Usage"
     ```pycon3
-    >>> from bs4 import BeautifulSoup as bs
+    >>> from bs4 import BeautifulSoup as bsx
     >>> html = """
     ... <html>
     ... <head></head>
@@ -745,6 +749,10 @@ as `:any-link`.
 
 !!! tip "Additional Reading"
     https://developer.mozilla.org/en-US/docs/Web/CSS/:link
+
+!!! new "New in 2.2"
+    The CSS specification recently updated to not include `#!html <link>` in the definition; therefore, Soup Sieve has
+    removed it as well.
 
 ## `:not()` {:#:not}
 

--- a/soupsieve/__meta__.py
+++ b/soupsieve/__meta__.py
@@ -185,5 +185,5 @@ def parse_version(ver, pre=False):
     return Version(major, minor, micro, release, pre, post, dev)
 
 
-__version_info__ = Version(2, 1, 0, "final")
+__version_info__ = Version(2, 2, 0, ".dev")
 __version__ = __version_info__._get_canonical()

--- a/soupsieve/css_parser.py
+++ b/soupsieve/css_parser.py
@@ -1063,7 +1063,7 @@ class CSSParser(object):
 
 # CSS pattern for `:link` and `:any-link`
 CSS_LINK = CSSParser(
-    'html|*:is(a, area, link)[href]'
+    'html|*:is(a, area)[href]'
 ).process_selectors(flags=FLG_PSEUDO | FLG_HTML)
 # CSS pattern for `:checked`
 CSS_CHECKED = CSSParser(


### PR DESCRIPTION
I'm really glad they dropped <link> as it didn't make much sense.