### PR TITLE
Remove SO attributions to sidestep licensing greyness

### DIFF
--- a/soupsieve/util.py
+++ b/soupsieve/util.py
@@ -42,22 +42,24 @@ class SelectorSyntaxError(Exception):
 
 def deprecated(message, stacklevel=2):  # pragma: no cover
     """
-    Raise a `DeprecationWarning` when wrapped function/method is called.
-
-    Borrowed from https://stackoverflow.com/a/48632082/866026
+    Raise a DeprecationWarning when wrapped function/method is called.
+    
+    Usage:
+        @deprecated("This method will be removed in version X; use Y instead.")
+        def some_method()"
+            pass
     """
-
-    def _decorator(func):
+    def wrapper(func):
         @wraps(func)
-        def _func(*args, **kwargs):
+        def deprecated_func(*args, **kwargs):
             warnings.warn(
-                "'{}' is deprecated. {}".format(func.__name__, message),
+                f"'{func.__name__}' is deprecated. {message}",
                 category=DeprecationWarning,
                 stacklevel=stacklevel
             )
             return func(*args, **kwargs)
-        return _func
-    return _decorator
+        return deprecated_func
+    return wrapper
 
 
 def warn_deprecated(message, stacklevel=2):  # pragma: no cover


### PR DESCRIPTION
Hey @facelessuser,

This package also got flagged in our FOSS scan. I promise we're not following you around. ;)
Have offered the same soln as in Python-Markdown/markdown#1149

Cheers,