### PR TITLE
Allow `:is()`, `:has()`, and `:where()` to forgive empty slots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.DS_Store
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2.3
+
+- **NEW**: `:has()`, `:is()`, and `:where()` now use use a forgiving selector list. While not as forgiving as due to
+  syntax errors as CSS might be, it will forgive such things as empty sets and empty slots due to multiple consecutive
+  commas, leading commas, or trailing commas. Essentially, these pseudo-classes will match all non-empty selectors and
+  ignore empty ones. As the scraping environment is different that a browser environment, it was chosen not to
+  aggressively forgive bad syntax and invalid features to ensure the user is alerted that their program may not perform
+  as expected.
+
 ## 2.2.1
 
 - **FIX**: Fix an issue with namespaces when one of the keys is `self`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -105,6 +105,6 @@ plugins:
   - search:
       separator: '[:\s\-]+'
   - git-revision-date-localized
-  - minify:
-      minify_html: true
+  # - minify:
+  #     minify_html: true
   - mkdocs_pymdownx_material_extras

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,4 +1,3 @@
 mkdocs_pymdownx_material_extras==1.2.2
 mkdocs-git-revision-date-localized-plugin
-mkdocs-minify-plugin
 pyspelling

--- a/soupsieve/__meta__.py
+++ b/soupsieve/__meta__.py
@@ -188,5 +188,5 @@ def parse_version(ver):
     return Version(major, minor, micro, release, pre, post, dev)
 
 
-__version_info__ = Version(2, 2, 1, "final")
+__version_info__ = Version(2, 3, 0, ".dev")
 __version__ = __version_info__._get_canonical()

--- a/soupsieve/css_match.py
+++ b/soupsieve/css_match.py
@@ -784,6 +784,9 @@ class _Match(object):
 
         found = False
 
+        if isinstance(relation[0], ct.SelectorNull) or relation[0].rel_type is None:
+            return found
+
         if relation[0].rel_type.startswith(':'):
             found = self.match_future_relations(el, relation)
         else:

--- a/tests/test_level3/test_not.py
+++ b/tests/test_level3/test_not.py
@@ -1,6 +1,7 @@
 """Test not selectors."""
 from .. import util
 from bs4 import BeautifulSoup as BS
+from soupsieve import SelectorSyntaxError
 
 
 class TestNot(util.TestCase):
@@ -55,3 +56,23 @@ class TestNot(util.TestCase):
         soup = BS('<span foo="something">text</span>', 'html.parser')
         soup.span['foo'] = None
         self.assertEqual(len(soup.select('span:not([foo])')), 0)
+
+    def test_invalid_pseudo_empty(self):
+        """Test pseudo class group with empty set."""
+
+        self.assert_raises(':not()', SelectorSyntaxError)
+
+    def test_invalid_pseudo_trailing_comma(self):
+        """Test pseudo class group with trailing comma."""
+
+        self.assert_raises(':not(.class,)', SelectorSyntaxError)
+
+    def test_invalid_pseudo_leading_comma(self):
+        """Test pseudo class group with leading comma."""
+
+        self.assert_raises(':not(,.class)', SelectorSyntaxError)
+
+    def test_invalid_pseudo_multi_comma(self):
+        """Test pseudo class group with multiple commas."""
+
+        self.assert_raises(':not(.this,,.that)', SelectorSyntaxError)

--- a/tests/test_level4/test_has.py
+++ b/tests/test_level4/test_has.py
@@ -129,20 +129,50 @@ class TestHas(util.TestCase):
             flags=util.HTML
         )
 
+    def test_has_empty(self):
+        """Test has with empty slot due to multiple commas."""
+
+        self.assert_selector(
+            self.MARKUP2,
+            'div:has()',
+            [],
+            flags=util.HTML
+        )
+
+    def test_has_multi_commas(self):
+        """Test has with empty slot due to multiple commas."""
+
+        self.assert_selector(
+            self.MARKUP2,
+            'div:has(> .bbbb, .ffff, , .jjjj)',
+            ['0', '4', '8'],
+            flags=util.HTML
+        )
+
+    def test_has_leading_commas(self):
+        """Test has with empty slot due to leading commas."""
+
+        self.assert_selector(
+            self.MARKUP2,
+            'div:has(, > .bbbb, .ffff, .jjjj)',
+            ['0', '4', '8'],
+            flags=util.HTML
+        )
+
+    def test_has_trailing_commas(self):
+        """Test has with empty slot due to trailing commas."""
+
+        self.assert_selector(
+            self.MARKUP2,
+            'div:has(> .bbbb, .ffff, .jjjj, )',
+            ['0', '4', '8'],
+            flags=util.HTML
+        )
+
     def test_invalid_incomplete_has(self):
         """Test `:has()` fails with just a combinator."""
 
         self.assert_raises(':has(>)', SelectorSyntaxError)
-
-    def test_invalid_has_empty(self):
-        """Test `:has()` fails with empty function parameters."""
-
-        self.assert_raises(':has()', SelectorSyntaxError)
-
-    def test_invalid_has_double_comma(self):
-        """Test `:has()` fails with consecutive commas."""
-
-        self.assert_raises(':has(> has,, a)', SelectorSyntaxError)
 
     def test_invalid_has_double_combinator(self):
         """Test `:has()` fails with consecutive combinators."""
@@ -155,13 +185,3 @@ class TestHas(util.TestCase):
         """Test `:has()` fails with trailing combinator."""
 
         self.assert_raises(':has(> has >)', SelectorSyntaxError)
-
-    def test_invalid_has_trailing_comma(self):
-        """Test `:has()` fails with trailing comma."""
-
-        self.assert_raises(':has(> has,)', SelectorSyntaxError)
-
-    def test_invalid_has_start_comma(self):
-        """Test `:has()` fails with trailing comma."""
-
-        self.assert_raises(':has(, p)', SelectorSyntaxError)

--- a/tests/test_level4/test_is.py
+++ b/tests/test_level4/test_is.py
@@ -24,6 +24,46 @@ class TestIs(util.TestCase):
             flags=util.HTML
         )
 
+    def test_is_multi_comma(self):
+        """Test multiple selectors but with an empty slot due to multiple commas."""
+
+        self.assert_selector(
+            self.MARKUP,
+            ":is(span, , a)",
+            ["1", "2"],
+            flags=util.HTML
+        )
+
+    def test_is_leading_comma(self):
+        """Test multiple selectors but with an empty slot due to leading commas."""
+
+        self.assert_selector(
+            self.MARKUP,
+            ":is(, span, a)",
+            ["1", "2"],
+            flags=util.HTML
+        )
+
+    def test_is_trailing_comma(self):
+        """Test multiple selectors but with an empty slot due to trailing commas."""
+
+        self.assert_selector(
+            self.MARKUP,
+            ":is(span, a, )",
+            ["1", "2"],
+            flags=util.HTML
+        )
+
+    def test_is_empty(self):
+        """Test empty `:is()` selector list."""
+
+        self.assert_selector(
+            self.MARKUP,
+            ":is()",
+            [],
+            flags=util.HTML
+        )
+
     def test_nested_is(self):
         """Test multiple nested selectors."""
 
@@ -84,11 +124,6 @@ class TestIs(util.TestCase):
         """Test invalid, orphaned pseudo close."""
 
         self.assert_raises('div)', SelectorSyntaxError)
-
-    def test_invalid_pseudo_dangling_comma(self):
-        """Test pseudo class group with trailing comma."""
-
-        self.assert_raises(':is(div,)', SelectorSyntaxError)
 
     def test_invalid_pseudo_open(self):
         """Test invalid pseudo close."""


### PR DESCRIPTION
Resolves #122