### PR TITLE
:has() should not have any kind of forgiving behavior

### DIFF
--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -1,13 +1,11 @@
 # Changelog
 
-## 2.5
+## 2.4
 
 - **NEW**: Update to support changes related to `:lang()` in the official CSS spec. `:lang("")` should match unspecified
   languages, e.g. `lang=""`, but not `lang=und`.
-
-## 2.4
-
-- **NEW**: `:nth-child()` and `:nth-last-child()` will forgive irregular comma usage.
+- **NEW**: Only `:is()` and `:where()` should allow forgiving selector lists according to latest CSS (as far as Soup
+  Sieve supports "forgiving" which is limited to empty selectors).
 - **NEW**: Formally drop Python 3.6.
 
 ## 2.3.2.post1

--- a/soupsieve/__meta__.py
+++ b/soupsieve/__meta__.py
@@ -193,5 +193,5 @@ def parse_version(ver: str) -> Version:
     return Version(major, minor, micro, release, pre, post, dev)
 
 
-__version_info__ = Version(2, 5, 0, "final", post=1)
+__version_info__ = Version(2, 4, 0, "final")
 __version__ = __version_info__._get_canonical()

--- a/tests/test_level4/test_has.py
+++ b/tests/test_level4/test_has.py
@@ -129,45 +129,20 @@ class TestHas(util.TestCase):
             flags=util.HTML
         )
 
-    def test_has_empty(self):
-        """Test has with empty slot due to multiple commas."""
+    def test_has_no_match(self):
+        """Test has with a non-matching selector."""
 
         self.assert_selector(
             self.MARKUP2,
-            'div:has()',
+            'div:has(:paused)',
             [],
             flags=util.HTML
         )
 
-    def test_has_multi_commas(self):
+    def test_has_empty(self):
         """Test has with empty slot due to multiple commas."""
 
-        self.assert_selector(
-            self.MARKUP2,
-            'div:has(> .bbbb, .ffff, , .jjjj)',
-            ['0', '4', '8'],
-            flags=util.HTML
-        )
-
-    def test_has_leading_commas(self):
-        """Test has with empty slot due to leading commas."""
-
-        self.assert_selector(
-            self.MARKUP2,
-            'div:has(, > .bbbb, .ffff, .jjjj)',
-            ['0', '4', '8'],
-            flags=util.HTML
-        )
-
-    def test_has_trailing_commas(self):
-        """Test has with empty slot due to trailing commas."""
-
-        self.assert_selector(
-            self.MARKUP2,
-            'div:has(> .bbbb, .ffff, .jjjj, )',
-            ['0', '4', '8'],
-            flags=util.HTML
-        )
+        self.assert_raises('div:has()', SelectorSyntaxError)
 
     def test_invalid_incomplete_has(self):
         """Test `:has()` fails with just a combinator."""

--- a/tests/test_level4/test_nth_child.py
+++ b/tests/test_level4/test_nth_child.py
@@ -46,13 +46,3 @@ class TestNthChild(util.TestCase):
             ['2', '6', '10'],
             flags=util.HTML
         )
-
-    def test_nth_child_forgive(self):
-        """Test that `nth` child forgives bad commas."""
-
-        self.assert_selector(
-            self.MARKUP,
-            ":nth-child(2n + 1 OF p.test,, span.test,)",
-            ['2', '6', '10'],
-            flags=util.HTML
-        )

--- a/tests/test_level4/test_nth_last_child.py
+++ b/tests/test_level4/test_nth_last_child.py
@@ -31,30 +31,3 @@ class TestNthLastChild(util.TestCase):
             ['1', '3', '5', '7', '9', '11'],
             flags=util.HTML
         )
-
-    def test_nth_last_child_forgive(self):
-        """Test `nth` last child forgives irregular commas."""
-
-        markup = """
-        <body>
-        <p id="0"></p>
-        <p id="1"></p>
-        <span id="2"></span>
-        <span id="3"></span>
-        <span id="4"></span>
-        <span id="5"></span>
-        <span id="6"></span>
-        <p id="7"></p>
-        <p id="8"></p>
-        <p id="9"></p>
-        <p id="10"></p>
-        <span id="11"></span>
-        </body>
-        """
-
-        self.assert_selector(
-            markup,
-            ":nth-last-child(2n + 1 of ,p[id],, span[id],)",
-            ['1', '3', '5', '7', '9', '11'],
-            flags=util.HTML
-        )


### PR DESCRIPTION
Recent CSS spec updated :has() to not be forgiving. This is to address JQuery issues. With that said, we do not offer true forgiving anyways, just comma forgiveness. As CSS will not be allowing forgiveness for relative selectors, we will not continue supporting it.