### PR TITLE
Improve pseudo-class error message

### DIFF
--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -2,8 +2,9 @@
 
 ## 2.6
 
--   **NEW** Add support for `&` as scoping root per the CSS Nesting Module, Level 1. When `&` is used outside the
+-   **NEW**: Add support for `&` as scoping root per the CSS Nesting Module, Level 1. When `&` is used outside the
     context of nesting, it is treated as the scoping root (equivalent to `:scope`).
+-   **FIX**: Improve error message when an unrecognized pseudo-class is used.
 
 ## 2.5
 

--- a/soupsieve/css_parser.py
+++ b/soupsieve/css_parser.py
@@ -655,9 +655,11 @@ class CSSParser:
                 m.start(0)
             )
         else:
-            raise ValueError(
+            raise SelectorSyntaxError(
                 f"'{pseudo}' was detected as a pseudo-class and is either unsupported or invalid. "
-                "If the syntax was not intended to be recognized as a pseudo-class, please escape the colon."
+                "If the syntax was not intended to be recognized as a pseudo-class, please escape the colon.",
+                self.pattern,
+                m.start(0)
             )
 
         return has_selector, is_html

--- a/soupsieve/css_parser.py
+++ b/soupsieve/css_parser.py
@@ -655,8 +655,9 @@ class CSSParser:
                 m.start(0)
             )
         else:
-            raise NotImplementedError(
-                f"'{pseudo}' pseudo-class is not implemented at this time"
+            raise ValueError(
+                f"'{pseudo}' was detected as a pseudo-class and is either unsupported or invalid. "
+                "If the syntax was not intended to be recognized as a pseudo-class, please escape the colon."
             )
 
         return has_selector, is_html

--- a/tests/test_level1/test_pseudo_class.py
+++ b/tests/test_level1/test_pseudo_class.py
@@ -1,5 +1,6 @@
 """Test general pseudo-class cases."""
 from .. import util
+from soupsieve import SelectorSyntaxError
 
 
 class TestPseudoClass(util.TestCase):
@@ -8,9 +9,9 @@ class TestPseudoClass(util.TestCase):
     def test_pseudo_class_not_implemented(self):
         """Test pseudo-class that is not implemented."""
 
-        self.assert_raises(':not-implemented', NotImplementedError)
+        self.assert_raises(':not-implemented', SelectorSyntaxError)
 
     def test_unrecognized_pseudo(self):
         """Test unrecognized pseudo class."""
 
-        self.assert_raises(':before', NotImplementedError)
+        self.assert_raises(':before', SelectorSyntaxError)


### PR DESCRIPTION
When encountering a pseudo-class that is unrecognized, we should not state it is "unsupported" a it may be entirely invalid. While there are some pseudo-classes that are valid but not supported, the status of such things can change all the time and our internal list may become outdated.

Additionally, sometimes users trying to incorrectly specify tags with namespaces can trigger this message as they may assume that because a namespace is declared in their document as `ns:element` that they can do this in CSS as well. This specific case is not easily detectable for us as we generically parse the syntax, not the intent of the syntax.

To clear up confusion, be more specific and simply state that anytime a pseudo-class is not recognized by soupsieve that it is either invalid or not recognizable by soupsieve. By stating both possibilities, this points out that pseudo-class syntax was noted and that it is unrecognized by soupsieve, regardless of status, and may be entirely invalid. Additionally, note that if it being recognized as a pseudo-class is a surprise that the colon can be escaped to avoid the recognition as such.