### PR TITLE
Fix license definition in project metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "hatchling.build"
 name = "soupsieve"
 description = "A modern CSS selector implementation for Beautiful Soup."
 readme = "README.md"
-license = "MIT"
+license = { text = "MIT" }
 requires-python = ">=3.8"
 authors = [
     { name = "Isaac Muse", email = "Isaac.Muse@gmail.com" },


### PR DESCRIPTION
The license definition in `pyproject.toml` is not valid according to the [specification](https://packaging.python.org/en/latest/specifications/pyproject-toml/#license).

As a result, the PyPI API returns `license: null` for this package: https://pypi.org/pypi/soupsieve/json

This PR fixes this.