### PR TITLE
Add new selectors and move some existing selectors out of experimental

### DIFF
--- a/docs/src/dictionary/en-custom.txt
+++ b/docs/src/dictionary/en-custom.txt
@@ -35,6 +35,8 @@ WIP
 XHTML
 accessor
 amongst
+autofill
+autofilled
 boolean
 builtin
 centric
@@ -45,6 +47,7 @@ deregister
 dev
 directionality
 formatter
+fullscreen
 hashable
 html
 iterable

--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -1,7 +1,14 @@
 # Changelog
 
-## 2.6.1
+## 2.7
 
+-   **NEW**: Add `:open` pseudo selector.
+-   **NEW**: Add `:muted` pseudo selector.
+-   **NEW**: Recognize the following pseudo selectors: `:autofill`, `:buffering`, `:fullscreen`, `:picture-in-picture`,
+    `:popover-open`, `:seeking`, `:stalled`, and `:volume-locked`. These selectors, while recognized, will not match any
+    element as they require a live environment to check element states and browser states. This just prevents Soup Sieve
+    from failing when any of these selectors are specified.
+-   **NEW**: A number of existing pseudo-classes are no longer noted as experimental.
 -   **FIX**: Typing fixes.
 
 ## 2.6

--- a/docs/src/markdown/selectors/pseudo-classes.md
+++ b/docs/src/markdown/selectors/pseudo-classes.md
@@ -8,7 +8,7 @@ not being in a live, browser environment. Pseudo classes that cannot be implemen
 non-applicable either are under consideration, have not yet been evaluated, or are too new and viewed as a risk to
 implement as they might not stick around.
 
-## `:any-link`:material-language-html5:{: title="HTML" data-md-color-primary="orange" .icon}:material-flask:{: title="Experimental" data-md-color-primary="purple" .icon} {:#:any-link}
+## `:any-link`:material-language-html5:{: title="HTML" data-md-color-primary="orange" .icon} {:#:any-link}
 
 Selects every `#!html <a>`, or `#!html <area>` element that has an `href` attribute, independent of
 whether it has been visited.
@@ -91,7 +91,7 @@ Selects any `#!html <input type="radio"/>`, `#!html <input type="checkbox"/>`, o
 https://developer.mozilla.org/en-US/docs/Web/CSS/:checked
 ///
 
-## `:default`:material-language-html5:{: title="HTML" data-md-color-primary="orange" .icon}:material-flask:{: title="Experimental" data-md-color-primary="purple" .icon} {:#:default}
+## `:default`:material-language-html5:{: title="HTML" data-md-color-primary="orange" .icon} {:#:default}
 
 Selects any form element that is the default among a group of related elements, including: `#!html <button>`,
 `#!html <input type="checkbox">`, `#!html <input type="radio">`, `#!html <option>` elements.
@@ -146,7 +146,7 @@ Selects any form element that is the default among a group of related elements, 
 https://developer.mozilla.org/en-US/docs/Web/CSS/:default
 ///
 
-## `:defined`:material-language-html5:{: title="HTML" data-md-color-primary="orange" .icon}</span>:material-flask:{: title="Experimental" data-md-color-primary="purple" .icon} {:#:defined}
+## `:defined`:material-language-html5:{: title="HTML" data-md-color-primary="orange" .icon} {:#:defined}
 
 In a browser environment, this represents *defined* elements (names without hyphens) and custom elements (names with
 hyphens) that have been properly added to the custom element registry. Since elements cannot be added to a custom
@@ -181,7 +181,7 @@ specific selector, so it doesn't apply to XML.
 https://developer.mozilla.org/en-US/docs/Web/CSS/:defined
 ///
 
-## `:dir()`:material-language-html5:{: title="HTML" data-md-color-primary="orange" .icon}:material-flask:{: title="Experimental" data-md-color-primary="purple" .icon} {:#:dir}
+## `:dir()`:material-language-html5:{: title="HTML" data-md-color-primary="orange" .icon} {:#:dir}
 
 Selects elements based on text directionality. Accepts either `ltr` or `rtl` for "left to right" and "right to left"
 respectively.
@@ -423,7 +423,7 @@ element:first-of-type
 https://developer.mozilla.org/en-US/docs/Web/CSS/:first-of-type
 ///
 
-## `:has()`:material-flask:{: title="Experimental" data-md-color-primary="purple" .icon} {:#has}
+## `:has()` {:#has}
 
 Selects an element if any of the relative selectors passed as parameters (which are relative to the `:scope` of the
 given element), match at least one element.
@@ -469,7 +469,7 @@ not to nest `:has()` if there are concerns.
 https://developer.mozilla.org/en-US/docs/Web/CSS/:has
 ///
 
-## `:in-range`:material-language-html5:{: title="HTML" data-md-color-primary="orange" .icon}:material-flask:{: title="Experimental" data-md-color-primary="purple" .icon} {:#:in-range}
+## `:in-range`:material-language-html5:{: title="HTML" data-md-color-primary="orange" .icon} {:#:in-range}
 
 Selects all `#!html <input>` elements whose values are in range according to their `type`, `min`, and `max` attributes.
 
@@ -501,7 +501,7 @@ Selects all `#!html <input>` elements whose values are in range according to the
 https://developer.mozilla.org/en-US/docs/Web/CSS/:in-range
 ///
 
-## `:indeterminate`:material-language-html5:{: title="HTML" data-md-color-primary="orange" .icon}:material-flask:{: title="Experimental" data-md-color-primary="purple" .icon} {:#:indeterminate}
+## `:indeterminate`:material-language-html5:{: title="HTML" data-md-color-primary="orange" .icon} {:#:indeterminate}
 
 Selects all form elements whose are in an indeterminate state.
 
@@ -564,7 +564,7 @@ An element is considered indeterminate if:
 https://developer.mozilla.org/en-US/docs/Web/CSS/:indeterminate
 ///
 
-## `:is()`:material-flask:{: title="Experimental" data-md-color-primary="purple" .icon} {:#:is}
+## `:is()` {:#:is}
 
 Selects an element, but only if it matches at least one selector in the selector list.
 
@@ -820,6 +820,48 @@ https://developer.mozilla.org/en-US/docs/Web/CSS/:link
 /// new | New in 2.2
 The CSS specification recently updated to not include `#!html <link>` in the definition; therefore, Soup Sieve has
 removed it as well.
+///
+
+## `:muted`:material-language-html5:{: title="HTML" data-md-color-primary="orange" .icon}:material-flask:{: title="Experimental" data-md-color-primary="purple" .icon} {:#:muted}
+
+Selects an element that is capable of being played or paused (such as an audio, video, or similar resource) and is
+currently "muted".
+
+Soup Sieve can only detect muted media elements that have the `muted` attribute explicitly applied.
+
+/// tab | Syntax
+```css
+:muted
+```
+///
+
+/// tab | Usage
+```pycon3
+>>> from bs4 import BeautifulSoup as bs
+>>> html = """
+... <html>
+... <head></head>
+... <body>
+... <video id="vid1" width="320" height="240" controls muted>
+...   <source src="movie.mp4" type="video/mp4">
+...   <source src="movie.ogg" type="video/ogg">
+...   Your browser does not support the video tag.
+... </video>
+... </body>
+... </html>
+... """
+>>> soup = bs(html, 'html5lib')
+>>> print(soup.select('video:muted'))
+[<video controls="" height="240" id="vid1" muted="" width="320">
+  <source src="movie.mp4" type="video/mp4"/>
+  <source src="movie.ogg" type="video/ogg"/>
+  Your browser does not support the video tag.
+</video>]
+```
+///
+
+/// tip | Additional Reading
+https://developer.mozilla.org/en-US/docs/Web/CSS/:muted
 ///
 
 ## `:not()` {:#:not}
@@ -1218,6 +1260,87 @@ element:nth-of-type(2n+2)
 https://developer.mozilla.org/en-US/docs/Web/CSS/:nth-of-type
 ///
 
+## `:open`:material-language-html5:{: title="HTML" data-md-color-primary="orange" .icon}:material-flask:{: title="Experimental" data-md-color-primary="purple" .icon} {:#:open}
+
+Selects an element that has open and closed states, but only when it is in the open state.
+
+Due to limitations of not being in a live, browser environment, Soup Sieve can currently only target `#!html <details>`
+and `#!html <dialog>` elements with an `open` attribute. It cannot target `<input>` elements (such as color pickers)
+when they are open as there is no indication in a non-live environment.
+
+/// tab | Syntax
+```css
+:open
+```
+///
+
+/// tab | Usage
+```pycon3
+>>> from bs4 import BeautifulSoup as bs
+>>> html = """
+... <html>
+... <head></head>
+... <body>
+... <details open>
+... <summary>A summary</summary>
+... <p>Content</p>
+... </details>
+... </body>
+... </html>
+... """
+>>> soup = bs(html, 'html5lib')
+>>> print(soup.select('details:open'))
+[<details open="">
+<summary>A summary</summary>
+<p>Content</p>
+</details>]
+```
+///
+
+/// tip | Additional Reading
+https://developer.mozilla.org/en-US/docs/Web/CSS/:open
+///
+
+## `:optional`:material-language-html5:{: title="HTML" data-md-color-primary="orange" .icon} {:#:optional}
+
+Selects any `#!html <input>`, `#!html <select>`, or `#!html <textarea>` element that does not have the `required`
+attribute set on it.
+
+/// tab | Syntax
+```css
+:optional
+```
+///
+
+/// tab | Usage
+```pycon3
+>>> from bs4 import BeautifulSoup as bs
+>>> html = """
+... <html>
+... <head></head>
+... <body>
+... <form>
+... <input type="name" required>
+... <input type="checkbox" required>
+... <input type="email">
+... <textarea name="name" cols="30" rows="10" required></textarea>
+... <select name="nm" required>
+...     <!-- options -->
+... </select>
+... </form>
+... </body>
+... </html>
+... """
+>>> soup = bs(html, 'html5lib')
+>>> print(soup.select(':optional'))
+[<input type="email"/>]
+```
+///
+
+/// tip | Additional Reading
+https://developer.mozilla.org/en-US/docs/Web/CSS/:optional
+///
+
 ## `:only-child` {:#:only-child}
 
 Selects element without any siblings.
@@ -1296,47 +1419,7 @@ element:only-of-type
 https://developer.mozilla.org/en-US/docs/Web/CSS/:only-of-type
 ///
 
-## `:optional`:material-language-html5:{: title="HTML" data-md-color-primary="orange" .icon}:material-flask:{: title="Experimental" data-md-color-primary="purple" .icon} {:#:optional}
-
-Selects any `#!html <input>`, `#!html <select>`, or `#!html <textarea>` element that does not have the `required`
-attribute set on it.
-
-/// tab | Syntax
-```css
-:optional
-```
-///
-
-/// tab | Usage
-```pycon3
->>> from bs4 import BeautifulSoup as bs
->>> html = """
-... <html>
-... <head></head>
-... <body>
-... <form>
-... <input type="name" required>
-... <input type="checkbox" required>
-... <input type="email">
-... <textarea name="name" cols="30" rows="10" required></textarea>
-... <select name="nm" required>
-...     <!-- options -->
-... </select>
-... </form>
-... </body>
-... </html>
-... """
->>> soup = bs(html, 'html5lib')
->>> print(soup.select(':optional'))
-[<input type="email"/>]
-```
-///
-
-/// tip | Additional Reading
-https://developer.mozilla.org/en-US/docs/Web/CSS/:optional
-///
-
-## `:out-of-range`:material-language-html5:{: title="HTML" data-md-color-primary="orange" .icon}:material-flask:{: title="Experimental" data-md-color-primary="purple" .icon} {:#:out-of-range}
+## `:out-of-range`:material-language-html5:{: title="HTML" data-md-color-primary="orange" .icon} {:#:out-of-range}
 
 Selects all `#!html <input>` elements whose values are out of range according to their `type`, `min`, and `max`
 attributes.
@@ -1369,7 +1452,7 @@ attributes.
 https://developer.mozilla.org/en-US/docs/Web/CSS/:out-of-range
 ///
 
-## `:placeholder-shown`:material-language-html5:{: title="HTML" data-md-color-primary="orange" .icon}:material-flask:{: title="Experimental" data-md-color-primary="purple" .icon} {:#:placeholder-shown}
+## `:placeholder-shown`:material-language-html5:{: title="HTML" data-md-color-primary="orange" .icon} {:#:placeholder-shown}
 
 Selects any `#!html <input>` or `#!html <textarea>` element that is currently displaying placeholder text via the
 `placeholder` attribute.
@@ -1414,7 +1497,7 @@ it can't account for the quirks of the parsers in this case without introducing 
 https://developer.mozilla.org/en-US/docs/Web/CSS/:placeholder-shown
 ///
 
-## `:read-only`:material-language-html5:{: title="HTML" data-md-color-primary="orange" .icon}:material-flask:{: title="Experimental" data-md-color-primary="purple" .icon} {:#:read-only}
+## `:read-only`:material-language-html5:{: title="HTML" data-md-color-primary="orange" .icon} {:#:read-only}
 
 Selects elements (such as `#!html <input>` or `#!html <textarea>`) that are *not* editable by the user. This does not
 just apply to form elements with `readonly` set, but it applies to **any** element that cannot be edited by the user.
@@ -1455,7 +1538,7 @@ just apply to form elements with `readonly` set, but it applies to **any** eleme
 https://developer.mozilla.org/en-US/docs/Web/CSS/:read-only
 ///
 
-## `:read-write`:material-language-html5:{: title="HTML" data-md-color-primary="orange" .icon}:material-flask:{: title="Experimental" data-md-color-primary="purple" .icon} {:#:read-write}
+## `:read-write`:material-language-html5:{: title="HTML" data-md-color-primary="orange" .icon} {:#:read-write}
 
 Selects elements (such as `#!html <input>` or `#!html <textarea>`) that are editable by the user. This does not just
 apply to form elements as it applies to **any** element that can be edited by the user, such as a `#!html <p>` element
@@ -1497,7 +1580,7 @@ with `contenteditable` set on it.
 https://developer.mozilla.org/en-US/docs/Web/CSS/:read-write
 ///
 
-## `:required`:material-language-html5:{: title="HTML" data-md-color-primary="orange" .icon}:material-flask:{: title="Experimental" data-md-color-primary="purple" .icon} {:#:required}
+## `:required`:material-language-html5:{: title="HTML" data-md-color-primary="orange" .icon} {:#:required}
 
 Selects any `#!html <input>`, `#!html <select>`, or `#!html <textarea>` element that has the `required` attribute set on
 it.
@@ -1577,7 +1660,7 @@ Selects the root element of a document tree.
 https://developer.mozilla.org/en-US/docs/Web/CSS/:root
 ///
 
-## `:scope`:material-flask:{: title="Experimental" data-md-color-primary="purple" .icon} {:#:scope}
+## `:scope` {:#:scope}
 
 /// new | New 2.6
 `&`, which was introduced in [CSS Nesting Level 1](https://www.w3.org/TR/css-nesting-1/#nest-selector) can be used as
@@ -1620,7 +1703,7 @@ others. If called on the Beautiful Soup object which represents the entire docum
 https://developer.mozilla.org/en-US/docs/Web/CSS/:scope
 ///
 
-## `:where()`:material-flask:{: title="Experimental" data-md-color-primary="purple" .icon} {:#:where}
+## `:where()` {:#:where}
 
 Selects an element, but only if it matches at least one selector in the selector list. In browsers, this also has zero
 specificity, but this only has relevance in a browser environment where you have multiple CSS styles, and specificity is

--- a/docs/src/markdown/selectors/unsupported.md
+++ b/docs/src/markdown/selectors/unsupported.md
@@ -17,6 +17,27 @@ Selects active elements.
 ```
 ///
 
+## `:autofill`:material-language-html5:{: title="HTML" data-md-color-primary="orange" .icon} {:#:autofill}
+
+Selects an `#!html <input>` element when its content has been autofilled by the browser.
+
+/// tab | Syntax
+```css
+:autofill
+```
+///
+
+## `:buffering`:material-language-html5:{: title="HTML" data-md-color-primary="orange" .icon}:material-flask:{: title="Experimental" data-md-color-primary="purple" .icon} {:#:buffering}
+
+Selects an element that is capable of being played or paused (such as an audio, video, or similar resource) and is
+currently "buffering".
+
+/// tab | Syntax
+```css
+:buffering
+```
+///
+
 ## `:current`:material-language-html5:{: title="HTML" data-md-color-primary="orange" .icon}:material-flask:{: title="Experimental" data-md-color-primary="purple" .icon} {:#:current}
 
 `:current` selects the element, or an ancestor of the element, that is currently being displayed. The functional form of
@@ -39,7 +60,7 @@ Represents an element that has received focus.
 ```
 ///
 
-## `:focus-visible`:material-language-html5:{: title="HTML" data-md-color-primary="orange" .icon}:material-flask:{: title="Experimental" data-md-color-primary="purple" .icon} {:#:focus-visible}
+## `:focus-visible`:material-language-html5:{: title="HTML" data-md-color-primary="orange" .icon} {:#:focus-visible}
 
 Selects an element that matches `:focus` and the user agent determines that the focus should be made evident on the
 element.
@@ -50,13 +71,23 @@ element.
 ```
 ///
 
-## `:focus-within`:material-language-html5:{: title="HTML" data-md-color-primary="orange" .icon}:material-flask:{: title="Experimental" data-md-color-primary="purple" .icon} {:#:focus-within}
+## `:focus-within`:material-language-html5:{: title="HTML" data-md-color-primary="orange" .icon} {:#:focus-within}
 
 Selects an element that has received focus or contains an element that has received focus.
 
 /// tab | Syntax
 ```css
 :focus-within
+```
+///
+
+## `:fullscreen`:material-language-html5:{: title="HTML" data-md-color-primary="orange" .icon}:material-flask:{: title="Experimental" data-md-color-primary="purple" .icon} {:#:fullscreen}
+
+Selects an element that is currently in fullscreen mode.
+
+/// tab | Syntax
+```css
+:fullscreen
 ```
 ///
 
@@ -70,7 +101,7 @@ Selects an element that is defined to occur entirely after a `:current` element.
 ```
 ///
 
-## `:host`:material-language-html5:{: title="HTML" data-md-color-primary="orange" .icon}:material-flask:{: title="Experimental" data-md-color-primary="purple" .icon} {:#host}
+## `:host`:material-language-html5:{: title="HTML" data-md-color-primary="orange" .icon} {:#host}
 
 `:host` selects the element hosting a shadow tree. While the function form of `:host()` takes a complex selector list
 and matches the shadow host only if it matches one of the selectors in the list.
@@ -135,6 +166,16 @@ currently "paused".
 ```
 ///
 
+## `:picture-in-picture`:material-language-html5:{: title="HTML" data-md-color-primary="orange" .icon}:material-flask:{: title="Experimental" data-md-color-primary="purple" .icon} {:#:picture-in-picture}
+
+Selects an element that is currently in "picture-in-picture" mode.
+
+/// tab | Syntax
+```css
+:picture-in-picture
+```
+///
+
 ## `:playing`:material-language-html5:{: title="HTML" data-md-color-primary="orange" .icon}:material-flask:{: title="Experimental" data-md-color-primary="purple" .icon} {:#:playing}
 
 Selects an element that is capable of being played or paused (such as an audio, video, or similar resource) and is
@@ -143,6 +184,38 @@ currently "playing".
 /// tab | Syntax
 ```css
 :playing
+```
+///
+
+## `:popover-open`:material-language-html5:{: title="HTML" data-md-color-primary="orange" .icon} {:#:popover-open}
+
+Selects a popover element (i.e., one with a popover attribute) that is in the showing state.
+
+/// tab | Syntax
+```css
+:popover-open
+```
+///
+
+## `:seeking`:material-language-html5:{: title="HTML" data-md-color-primary="orange" .icon}:material-flask:{: title="Experimental" data-md-color-primary="purple" .icon} {:#:seeking}
+
+Selects an element that is capable of being played or paused (such as an audio, video, or similar resource) and is
+currently "seeking".
+
+/// tab | Syntax
+```css
+:seeking
+```
+///
+
+## `:stalled`:material-language-html5:{: title="HTML" data-md-color-primary="orange" .icon}:material-flask:{: title="Experimental" data-md-color-primary="purple" .icon} {:#:stalled}
+
+Selects an element that is capable of being played or paused (such as an audio, video, or similar resource) and is
+currently "stalled".
+
+/// tab | Syntax
+```css
+:stalled
 ```
 ///
 
@@ -183,6 +256,17 @@ Selects links that have already been visited.
 /// tab | Syntax
 ```css
 :visited
+```
+///
+
+## `:volume-locked`:material-language-html5:{: title="HTML" data-md-color-primary="orange" .icon}:material-flask:{: title="Experimental" data-md-color-primary="purple" .icon} {:#:volume-locked}
+
+Selects an element that is capable of being played or paused (such as an audio, video, or similar resource) and whose
+volume is currently locked by the user.
+
+/// tab | Syntax
+```css
+:volume-locked
 ```
 ///
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,7 +4,7 @@ repo_url: https://github.com/facelessuser/soupsieve
 edit_uri: tree/main/docs/src/markdown
 site_description: A modern CSS selector library for Beautiful Soup.
 copyright: |
-  Copyright &copy; 2018 - 2024 <a href="https://github.com/facelessuser"  target="_blank" rel="noopener">Isaac Muse</a>
+  Copyright &copy; 2018 - 2025 <a href="https://github.com/facelessuser"  target="_blank" rel="noopener">Isaac Muse</a>
 
 docs_dir: docs/src/markdown
 theme:
@@ -151,6 +151,9 @@ markdown_extensions:
   - pymdownx.blocks.definition:
   - pymdownx.blocks.tab:
       alternate_style: True
+  - pymdownx.blocks.caption:
+  - pymdownx.fancylists:
+      inject_style: true
 
 extra:
   social:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,7 +129,7 @@ deps =
     -rrequirements/docs.txt
 commands =
     mkdocs build --clean --verbose --strict
-    pyspelling
+    pyspelling -j 8
 
 [testenv:lint]
 passenv = *

--- a/soupsieve/__meta__.py
+++ b/soupsieve/__meta__.py
@@ -193,5 +193,5 @@ def parse_version(ver: str) -> Version:
     return Version(major, minor, micro, release, pre, post, dev)
 
 
-__version_info__ = Version(2, 6, 1, "final")
+__version_info__ = Version(2, 7, 0, "final")
 __version__ = __version_info__._get_canonical()

--- a/soupsieve/css_match.py
+++ b/soupsieve/css_match.py
@@ -56,7 +56,7 @@ FEB_LEAP_MONTH = 29
 DAYS_IN_WEEK = 7
 
 
-class _FakeParent(bs4.Tag):
+class _FakeParent:
     """
     Fake parent class.
 
@@ -129,7 +129,7 @@ class _DocumentNav:
         return cls.is_navigable_string(obj) and not cls.is_special_string(obj)
 
     @staticmethod
-    def create_fake_parent(el: bs4.Tag) -> bs4.Tag:
+    def create_fake_parent(el: bs4.Tag) -> _FakeParent:
         """Create fake parent for a given element."""
 
         return _FakeParent(el)
@@ -971,7 +971,7 @@ class CSSMatch(_DocumentNav):
                 break
             parent = self.get_parent(el)  # type: bs4.Tag | None
             if parent is None:
-                parent = self.create_fake_parent(el)
+                parent = cast('bs4.Tag', self.create_fake_parent(el))
             last = n.last
             last_index = len(parent) - 1
             index = last_index if last else 0

--- a/soupsieve/css_parser.py
+++ b/soupsieve/css_parser.py
@@ -18,6 +18,7 @@ PSEUDO_SIMPLE = {
     ":first-child",
     ":first-of-type",
     ":in-range",
+    ":open",
     ":out-of-range",
     ":last-child",
     ":last-of-type",
@@ -36,26 +37,35 @@ PSEUDO_SIMPLE = {
     ':read-write',
     ':required',
     ':scope',
-    ':defined'
+    ':defined',
+    ':muted'
 }
 
 # Supported, simple pseudo classes that match nothing in the Soup Sieve environment
 PSEUDO_SIMPLE_NO_MATCH = {
     ':active',
+    ':autofill',
+    ':buffering',
     ':current',
     ':focus',
     ':focus-visible',
     ':focus-within',
+    ':fullscreen',
     ':future',
     ':host',
     ':hover',
     ':local-link',
     ':past',
     ':paused',
+    ':picture-in-picture',
     ':playing',
+    ':popover-open',
+    ':seeking',
+    ':stalled',
     ':target',
     ':target-within',
     ':user-invalid',
+    ':volume-locked',
     ':visited'
 }
 
@@ -606,6 +616,10 @@ class CSSParser:
                 sel.selectors.append(CSS_ENABLED)
             elif pseudo == ":required":
                 sel.selectors.append(CSS_REQUIRED)
+            elif pseudo == ":muted":
+                sel.selectors.append(CSS_MUTED)
+            elif pseudo == ":open":
+                sel.selectors.append(CSS_OPEN)
             elif pseudo == ":optional":
                 sel.selectors.append(CSS_OPTIONAL)
             elif pseudo == ":read-only":
@@ -1287,3 +1301,18 @@ CSS_OUT_OF_RANGE = CSSParser(
     )
     '''
 ).process_selectors(flags=FLG_PSEUDO | FLG_OUT_OF_RANGE | FLG_HTML)
+
+# CSS pattern for :open
+CSS_OPEN = CSSParser(
+    '''
+    html|*:is(details, dialog)[open]
+    '''
+).process_selectors(flags=FLG_PSEUDO | FLG_HTML)
+
+
+# CSS pattern for :muted
+CSS_MUTED = CSSParser(
+    '''
+    html|*:is(video, audio)[muted]
+    '''
+).process_selectors(flags=FLG_PSEUDO | FLG_HTML)

--- a/tests/test_level4/test_muted.py
+++ b/tests/test_level4/test_muted.py
@@ -1,0 +1,47 @@
+"""Test muted selectors."""
+from .. import util
+
+
+class TestPaused(util.TestCase):
+    """Test paused selectors."""
+
+    MARKUP = """
+    <!DOCTYPE html>
+    <html>
+    <body>
+
+    <video id="vid1" width="320" height="240" controls muted>
+      <source src="movie.mp4" type="video/mp4">
+      <source src="movie.ogg" type="video/ogg">
+      Your browser does not support the video tag.
+    </video>
+
+    <video id="vid2" width="320" height="240" controls>
+      <source src="movie.mp4" type="video/mp4">
+      <source src="movie.ogg" type="video/ogg">
+      Your browser does not support the video tag.
+    </video>
+
+    </body>
+    </html>
+    """
+
+    def test_muted(self):
+        """Test muted."""
+
+        self.assert_selector(
+            self.MARKUP,
+            "video:muted",
+            ['vid1'],
+            flags=util.HTML
+        )
+
+    def test_not_muted(self):
+        """Test not muted."""
+
+        self.assert_selector(
+            self.MARKUP,
+            "video:not(:muted)",
+            ["vid2"],
+            flags=util.HTML
+        )

--- a/tests/test_level4/test_open.py
+++ b/tests/test_level4/test_open.py
@@ -66,7 +66,7 @@ class TestOpen(util.TestCase):
         )
 
     def test_not_open(self):
-        """Test not open"""
+        """Test not open."""
 
         self.assert_selector(
             self.MARKUP,

--- a/tests/test_level4/test_open.py
+++ b/tests/test_level4/test_open.py
@@ -1,0 +1,76 @@
+"""Test open selectors."""
+from .. import util
+
+
+class TestOpen(util.TestCase):
+    """Test open selectors."""
+
+    MARKUP = """
+    <!DOCTYPE html>
+    <html>
+    <body>
+
+    <details id="1">
+    <summary>This is closed.</summary<
+    <p>A closed details element.</p>
+    </details>
+
+    <details id="2" open>
+    <summary>This is open.</summary<
+    <p>An open details element.</p>
+    </details>
+
+    <dialog id="3" open>
+      <p>Greetings, one and all!</p>
+      <form method="dialog">
+        <button>OK</button>
+      </form>
+    </dialog>
+
+    <dialog id="4">
+      <p>Goodbye, one and all!</p>
+      <form method="dialog">
+        <button>OK</button>
+      </form>
+    </dialog>
+
+    </body>
+    </html>
+    """
+
+    def test_open(self):
+        """Test open."""
+
+        self.assert_selector(
+            self.MARKUP,
+            ":open",
+            ['2', '3'],
+            flags=util.HTML
+        )
+
+    def test_targted_open(self):
+        """Test targeted open."""
+
+        self.assert_selector(
+            self.MARKUP,
+            "details:open",
+            ['2'],
+            flags=util.HTML
+        )
+
+        self.assert_selector(
+            self.MARKUP,
+            "dialog:open",
+            ['3'],
+            flags=util.HTML
+        )
+
+    def test_not_open(self):
+        """Test not open"""
+
+        self.assert_selector(
+            self.MARKUP,
+            ":is(dialog, details):not(:open)",
+            ["1", "4"],
+            flags=util.HTML
+        )


### PR DESCRIPTION
- Add `:open` and `:muted`
- Recognize `:autofill`, `:buffering`, `:fullscreen`, `:picture-in-picture`, `:popover-open`, `:seeking`, `:stalled`, and `:volume-locked`.
- Move various existing pseudo-classes out of experimental status.