### PR TITLE
Switch to trusted publishing for package upload in CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,6 +37,12 @@ jobs:
         git push gh-token gh-pages
 
   pypi:
+    environment:
+      name: pypi
+      url: https://pypi.org/p/soupsieve
+    permissions:
+      id-token: write
+
     runs-on: ubuntu-latest
 
     steps:
@@ -51,5 +57,4 @@ jobs:
       - name: Publish
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: __token__
-          password: ${{ secrets.PYPI_TOKEN }}
+          print-hash: true


### PR DESCRIPTION
Trusted publishing (with attestations) means I can know for certain that what I download from PyPI is the same artefact which was generated in GitHub CI, meaning that what I see in GitHub is the same as what is installed - handy for auditing (rather than having to manually review all of the installed files on each release).

See [the Python packaging documentation](https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/#configuring-trusted-publishing), [the PyPI documentation](https://docs.pypi.org/trusted-publishers/), and [the official pypi-publish GitHub action documentation](https://github.com/pypa/gh-action-pypi-publish?tab=readme-ov-file#trusted-publishing) on trusted publishing - you'll need to configure an environment in PyPI and GitHub. You will be able to remove the PYPI_TOKEN project secret.