### PR TITLE
Update hatchling version requirement in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "hatchling>=0.21.1",
+    "hatchling>=1.26",
 ]
 build-backend = "hatchling.build"
 


### PR DESCRIPTION
Old versions of hatchling error out with "Unknown classifier in field `project.classifiers`: Programming Language :: Python :: 3.14" because they don't know about Python 3.14.