### PR TITLE
Build patterns and regexes lazily in css_parser

### DIFF
--- a/soupsieve/css_parser.py
+++ b/soupsieve/css_parser.py
@@ -8,6 +8,7 @@ from . import css_types as ct
 from .util import SelectorSyntaxError
 import warnings
 from typing import Match, Any, Iterator, cast
+from dataclasses import dataclass
 
 UNICODE_REPLACEMENT_CHAR = 0xFFFD
 
@@ -430,17 +431,22 @@ class _Selector:
     __repr__ = __str__
 
 
+@dataclass
+class PseudoSelector:
+    selector: str
+    flags: int
+
 # CSS pattern for `:link` and `:any-link`
-CSS_LINK = ('html|*:is(a, area)[href]', 0)
+CSS_LINK = PseudoSelector('html|*:is(a, area)[href]', 0)
 # CSS pattern for `:checked`
-CSS_CHECKED = (
+CSS_CHECKED = PseudoSelector(
     '''
     html|*:is(input[type=checkbox], input[type=radio])[checked], html|option[selected]
     ''',
     0
 )
 # CSS pattern for `:default` (must compile CSS_CHECKED first)
-CSS_DEFAULT = (
+CSS_DEFAULT = PseudoSelector(
     '''
     :checked,
 
@@ -453,7 +459,7 @@ CSS_DEFAULT = (
     FLG_DEFAULT
 )
 # CSS pattern for `:indeterminate`
-CSS_INDETERMINATE = (
+CSS_INDETERMINATE = PseudoSelector(
     '''
     html|input[type="checkbox"][indeterminate],
     html|input[type="radio"]:is(:not([name]), [name=""]):not([checked]),
@@ -468,7 +474,7 @@ CSS_INDETERMINATE = (
     FLG_INDETERMINATE
 )
 # CSS pattern for `:disabled`
-CSS_DISABLED = (
+CSS_DISABLED = PseudoSelector(
     '''
     html|*:is(input:not([type=hidden]), button, select, textarea, fieldset, optgroup, option, fieldset)[disabled],
     html|optgroup[disabled] > html|option,
@@ -479,18 +485,18 @@ CSS_DISABLED = (
     0
 )
 # CSS pattern for `:enabled`
-CSS_ENABLED = (
+CSS_ENABLED = PseudoSelector(
     '''
     html|*:is(input:not([type=hidden]), button, select, textarea, fieldset, optgroup, option, fieldset):not(:disabled)
     ''',
     FLG_HTML
 )
 # CSS pattern for `:required`
-CSS_REQUIRED = ('html|*:is(input, textarea, select)[required]', 0)
+CSS_REQUIRED = PseudoSelector('html|*:is(input, textarea, select)[required]', 0)
 # CSS pattern for `:optional`
-CSS_OPTIONAL = ('html|*:is(input, textarea, select):not([required])', 0)
+CSS_OPTIONAL = PseudoSelector('html|*:is(input, textarea, select):not([required])', 0)
 # CSS pattern for `:placeholder-shown`
-CSS_PLACEHOLDER_SHOWN = (
+CSS_PLACEHOLDER_SHOWN = PseudoSelector(
     '''
     html|input:is(
         :not([type]),
@@ -508,7 +514,7 @@ CSS_PLACEHOLDER_SHOWN = (
     FLG_PLACEHOLDER_SHOWN
 )
 # CSS pattern for `:read-write` (CSS_DISABLED must be compiled first)
-CSS_READ_WRITE = (
+CSS_READ_WRITE = PseudoSelector(
     '''
     html|*:is(
         textarea,
@@ -534,9 +540,9 @@ CSS_READ_WRITE = (
     0
 )
 # CSS pattern for `:read-only`
-CSS_READ_ONLY = ('html|*:not(:read-write)', 0)
+CSS_READ_ONLY = PseudoSelector('html|*:not(:read-write)', 0)
 # CSS pattern for `:in-range`
-CSS_IN_RANGE = (
+CSS_IN_RANGE = PseudoSelector(
     '''
     html|input:is(
         [type="date"],
@@ -554,7 +560,7 @@ CSS_IN_RANGE = (
     FLG_IN_RANGE
 )
 # CSS pattern for `:out-of-range`
-CSS_OUT_OF_RANGE = (
+CSS_OUT_OF_RANGE = PseudoSelector(
     '''
     html|input:is(
         [type="date"],
@@ -573,11 +579,11 @@ CSS_OUT_OF_RANGE = (
 )
 
 # CSS pattern for :open
-CSS_OPEN = ('html|*:is(details, dialog)[open]', 0)
+CSS_OPEN = PseudoSelector('html|*:is(details, dialog)[open]', 0)
 
 
 # CSS pattern for :muted
-CSS_MUTED = ('html|*:is(video, audio)[muted]', 0)
+CSS_MUTED = PseudoSelector('html|*:is(video, audio)[muted]', 0)
 
 
 class CSSParser:
@@ -612,7 +618,7 @@ class CSSParser:
     )
 
     # Pseudos that expand to selectors
-    pseudo_selectors: dict[str, tuple[str, int] | ct.SelectorList] = {
+    pseudo_selectors: dict[str, PseudoSelector | ct.SelectorList] = {
         ':link': CSS_LINK,
         ':any-link': CSS_LINK,
         ':checked': CSS_CHECKED,
@@ -791,16 +797,13 @@ class CSSParser:
             elif pseudo == ':empty':
                 sel.flags |= ct.SEL_EMPTY
             elif pseudo in self.pseudo_selectors:
-                if isinstance(self.pseudo_selectors[pseudo], tuple):
-                    selector = self.pseudo_selectors[pseudo][0]
-                    flags = self.pseudo_selectors[pseudo][1]
-                    assert isinstance(selector, str) and isinstance(flags, int)
-                    self.pseudo_selectors[pseudo] = CSSParser(selector).process_selectors(
-                        flags=FLG_PSEUDO | FLG_HTML | flags
-                    )
-
                 pseudo_selector = self.pseudo_selectors[pseudo]
-                assert isinstance(pseudo_selector, ct.SelectorList)
+                if isinstance(pseudo_selector, PseudoSelector):
+                    self.pseudo_selectors[pseudo] = pseudo_selector = CSSParser(
+                        pseudo_selector.selector
+                    ).process_selectors(
+                        flags=FLG_PSEUDO | FLG_HTML | pseudo_selector.flags
+                    )
 
                 self.count += pseudo_selector.count
                 self.check_count()

--- a/soupsieve/css_parser.py
+++ b/soupsieve/css_parser.py
@@ -309,7 +309,7 @@ class SelectorPattern:
         """Initialize."""
 
         self.name = name
-        self.re_pattern = re.compile(pattern, re.I | re.X | re.U)
+        self.re_pattern = pattern
 
     def get_name(self) -> str:
         """Get name."""
@@ -318,6 +318,8 @@ class SelectorPattern:
 
     def match(self, selector: str, index: int, flags: int) -> Match[str] | None:
         """Match the selector."""
+        if isinstance(self.re_pattern, str):
+            self.re_pattern = re.compile(self.re_pattern, re.I | re.X | re.U)
 
         return self.re_pattern.match(selector, index)
 
@@ -427,13 +429,162 @@ class _Selector:
     __repr__ = __str__
 
 
+# CSS pattern for `:link` and `:any-link`
+CSS_LINK = ('html|*:is(a, area)[href]', 0)
+# CSS pattern for `:checked`
+CSS_CHECKED = (
+    '''
+    html|*:is(input[type=checkbox], input[type=radio])[checked], html|option[selected]
+    ''',
+    0
+)
+# CSS pattern for `:default` (must compile CSS_CHECKED first)
+CSS_DEFAULT = (
+    '''
+    :checked,
+
+    /*
+    This pattern must be at the end.
+    Special logic is applied to the last selector.
+    */
+    html|form html|*:is(button, input)[type="submit"]
+    ''',
+    FLG_DEFAULT
+)
+# CSS pattern for `:indeterminate`
+CSS_INDETERMINATE = (
+    '''
+    html|input[type="checkbox"][indeterminate],
+    html|input[type="radio"]:is(:not([name]), [name=""]):not([checked]),
+    html|progress:not([value]),
+
+    /*
+    This pattern must be at the end.
+    Special logic is applied to the last selector.
+    */
+    html|input[type="radio"][name]:not([name='']):not([checked])
+    ''',
+    FLG_INDETERMINATE
+)
+# CSS pattern for `:disabled`
+CSS_DISABLED = (
+    '''
+    html|*:is(input:not([type=hidden]), button, select, textarea, fieldset, optgroup, option, fieldset)[disabled],
+    html|optgroup[disabled] > html|option,
+    html|fieldset[disabled] > html|*:is(input:not([type=hidden]), button, select, textarea, fieldset),
+    html|fieldset[disabled] >
+        html|*:not(legend:nth-of-type(1)) html|*:is(input:not([type=hidden]), button, select, textarea, fieldset)
+    ''',
+    0
+)
+# CSS pattern for `:enabled`
+CSS_ENABLED = (
+    '''
+    html|*:is(input:not([type=hidden]), button, select, textarea, fieldset, optgroup, option, fieldset):not(:disabled)
+    ''',
+    FLG_HTML
+)
+# CSS pattern for `:required`
+CSS_REQUIRED = ('html|*:is(input, textarea, select)[required]', 0)
+# CSS pattern for `:optional`
+CSS_OPTIONAL = ('html|*:is(input, textarea, select):not([required])', 0)
+# CSS pattern for `:placeholder-shown`
+CSS_PLACEHOLDER_SHOWN = (
+    '''
+    html|input:is(
+        :not([type]),
+        [type=""],
+        [type=text],
+        [type=search],
+        [type=url],
+        [type=tel],
+        [type=email],
+        [type=password],
+        [type=number]
+    )[placeholder]:not([placeholder='']):is(:not([value]), [value=""]),
+    html|textarea[placeholder]:not([placeholder=''])
+    ''',
+    FLG_PLACEHOLDER_SHOWN
+)
+# CSS pattern for `:read-write` (CSS_DISABLED must be compiled first)
+CSS_READ_WRITE = (
+    '''
+    html|*:is(
+        textarea,
+        input:is(
+            :not([type]),
+            [type=""],
+            [type=text],
+            [type=search],
+            [type=url],
+            [type=tel],
+            [type=email],
+            [type=number],
+            [type=password],
+            [type=date],
+            [type=datetime-local],
+            [type=month],
+            [type=time],
+            [type=week]
+        )
+    ):not([readonly], :disabled),
+    html|*:is([contenteditable=""], [contenteditable="true" i])
+    ''',
+    0
+)
+# CSS pattern for `:read-only`
+CSS_READ_ONLY = ('html|*:not(:read-write)', 0)
+# CSS pattern for `:in-range`
+CSS_IN_RANGE = (
+    '''
+    html|input:is(
+        [type="date"],
+        [type="month"],
+        [type="week"],
+        [type="time"],
+        [type="datetime-local"],
+        [type="number"],
+        [type="range"]
+    ):is(
+        [min],
+        [max]
+    )
+    ''',
+    FLG_IN_RANGE
+)
+# CSS pattern for `:out-of-range`
+CSS_OUT_OF_RANGE = (
+    '''
+    html|input:is(
+        [type="date"],
+        [type="month"],
+        [type="week"],
+        [type="time"],
+        [type="datetime-local"],
+        [type="number"],
+        [type="range"]
+    ):is(
+        [min],
+        [max]
+    )
+    ''',
+    FLG_OUT_OF_RANGE
+)
+
+# CSS pattern for :open
+CSS_OPEN = ('html|*:is(details, dialog)[open]', 0)
+
+
+# CSS pattern for :muted
+CSS_MUTED = ('html|*:is(video, audio)[muted]', 0)
+
+
 class CSSParser:
     """Parse CSS selectors."""
 
     css_tokens = (
-        (SelectorPattern, "pseudo_close", PAT_PSEUDO_CLOSE),
-        (
-            SpecialPseudoPattern,
+        SelectorPattern("pseudo_close", PAT_PSEUDO_CLOSE),
+        SpecialPseudoPattern(
             (
                 (
                     "pseudo_contains",
@@ -447,17 +598,37 @@ class CSSParser:
                 ("pseudo_dir", (':dir',), PAT_PSEUDO_DIR, SelectorPattern)
             )
         ),
-        (SelectorPattern, "pseudo_class_custom", PAT_PSEUDO_CLASS_CUSTOM),
-        (SelectorPattern, "pseudo_class", PAT_PSEUDO_CLASS),
-        (SelectorPattern, "pseudo_element", PAT_PSEUDO_ELEMENT),
-        (SelectorPattern, "amp", PAT_AMP),
-        (SelectorPattern, "at_rule", PAT_AT_RULE),
-        (SelectorPattern, "id", PAT_ID),
-        (SelectorPattern, "class", PAT_CLASS),
-        (SelectorPattern, "tag", PAT_TAG),
-        (SelectorPattern, "attribute", PAT_ATTR),
-        (SelectorPattern, "combine", PAT_COMBINE)
+        SelectorPattern("pseudo_class_custom", PAT_PSEUDO_CLASS_CUSTOM),
+        SelectorPattern("pseudo_class", PAT_PSEUDO_CLASS),
+        SelectorPattern("pseudo_element", PAT_PSEUDO_ELEMENT),
+        SelectorPattern("amp", PAT_AMP),
+        SelectorPattern("at_rule", PAT_AT_RULE),
+        SelectorPattern("id", PAT_ID),
+        SelectorPattern("class", PAT_CLASS),
+        SelectorPattern("tag", PAT_TAG),
+        SelectorPattern("attribute", PAT_ATTR),
+        SelectorPattern("combine", PAT_COMBINE)
     )
+
+    # Pseudos that expand to selectors
+    pseudo_selectors = {
+        ':link': CSS_LINK,
+        ':any-link': CSS_LINK,
+        ':checked': CSS_CHECKED,
+        ':default': CSS_DEFAULT,
+        ':indeterminate': CSS_INDETERMINATE,
+        ':disabled': CSS_DISABLED,
+        ':enabled': CSS_ENABLED,
+        ':required': CSS_REQUIRED,
+        ':muted': CSS_MUTED,
+        ':open': CSS_OPEN,
+        ':optional': CSS_OPTIONAL,
+        ':read-only': CSS_READ_ONLY,
+        ':read-write': CSS_READ_WRITE,
+        ':in-range': CSS_IN_RANGE,
+        ':out-of-range': CSS_OUT_OF_RANGE,
+        ':placeholder-shown': CSS_PLACEHOLDER_SHOWN
+    }
 
     def __init__(
         self,
@@ -606,26 +777,6 @@ class CSSParser:
         if complex_pseudo and pseudo in PSEUDO_COMPLEX:
             has_selector = self.parse_pseudo_open(sel, pseudo, has_selector, iselector, m.end(0))
         elif not complex_pseudo and pseudo in PSEUDO_SIMPLE:
-            # Pseudos that expand to selectors
-            PSEUDO_SELECTORS = {
-                ':link': CSS_LINK,
-                ':any-link': CSS_LINK,
-                ':checked': CSS_CHECKED,
-                ':default': CSS_DEFAULT,
-                ':indeterminate': CSS_INDETERMINATE,
-                ':disabled': CSS_DISABLED,
-                ':enabled': CSS_ENABLED,
-                ':required': CSS_REQUIRED,
-                ':muted': CSS_MUTED,
-                ':open': CSS_OPEN,
-                ':optional': CSS_OPTIONAL,
-                ':read-only': CSS_READ_ONLY,
-                ':read-write': CSS_READ_WRITE,
-                ':in-range': CSS_IN_RANGE,
-                ':out-of-range': CSS_OUT_OF_RANGE,
-                ':placeholder-shown': CSS_PLACEHOLDER_SHOWN
-            }
-
             if pseudo == ':root':
                 sel.flags |= ct.SEL_ROOT
             elif pseudo == ':defined':
@@ -635,15 +786,17 @@ class CSSParser:
                 sel.flags |= ct.SEL_SCOPE
             elif pseudo == ':empty':
                 sel.flags |= ct.SEL_EMPTY
-            elif pseudo in PSEUDO_SELECTORS:
-                if isinstance(PSEUDO_SELECTORS[pseudo], tuple):
-                    PSEUDO_SELECTORS[pseudo] = CSSParser(
-                        PSEUDO_SELECTORS[pseudo][0]
-                    ).process_selectors(flags=FLG_PSEUDO | FLG_HTML | PSEUDO_SELECTORS[pseudo][1])
+            elif pseudo in self.pseudo_selectors:
+                if isinstance(self.pseudo_selectors[pseudo], tuple):
+                    self.pseudo_selectors[pseudo] = CSSParser(
+                        self.pseudo_selectors[pseudo][0]
+                    ).process_selectors(
+                        flags=FLG_PSEUDO | FLG_HTML | self.pseudo_selectors[pseudo][1]
+                    )
 
-                self.count += PSEUDO_SELECTORS[pseudo].count
+                self.count += self.pseudo_selectors[pseudo].count
                 self.check_count()
-                sel.selectors.append(PSEUDO_SELECTORS[pseudo])
+                sel.selectors.append(self.pseudo_selectors[pseudo])
             elif pseudo == ':first-child':
                 sel.nth.append(ct.SelectorNth(1, False, 0, False, False, ct.SelectorList()))
             elif pseudo == ':last-child':
@@ -742,11 +895,10 @@ class CSSParser:
                 nth_sel = self.parse_selectors(iselector, m.end(0), FLG_PSEUDO | FLG_OPEN)
             else:
                 # Use default `*|*` for `of S`.
-                global CSS_NTH_OF_S_DEFAULT
-                if not CSS_NTH_OF_S_DEFAULT:
-                   CSS_NTH_OF_S_DEFAULT = CSSParser('*|*').process_selectors(flags=FLG_PSEUDO)
+                if not hasattr(self, 'css_nth_of_s_default'):
+                   self.css_nth_of_s_default = CSSParser('*|*').process_selectors(flags=FLG_PSEUDO)
 
-                nth_sel = CSS_NTH_OF_S_DEFAULT
+                nth_sel = self.css_nth_of_s_default
                 self.count += nth_sel.count
                 self.check_count()
             if pseudo_sel == ':nth-child':
@@ -1142,8 +1294,6 @@ class CSSParser:
         while index <= end:
             m = None
             for v in self.css_tokens:
-                if not isinstance(v, SelectorPattern):
-                    v = v[0](*v[1:])
                 m = v.match(pattern, index, self.flags)
                 if m:
                     name = v.get_name()
@@ -1175,155 +1325,3 @@ class CSSParser:
         """Process selectors."""
 
         return self.parse_selectors(self.selector_iter(self.pattern), index, flags)
-
-
-# CSS pattern for `:link` and `:any-link`
-CSS_LINK = ('html|*:is(a, area)[href]', 0)
-# CSS pattern for `:checked`
-CSS_CHECKED = (
-    '''
-    html|*:is(input[type=checkbox], input[type=radio])[checked], html|option[selected]
-    ''',
-    0
-)
-# CSS pattern for `:default` (must compile CSS_CHECKED first)
-CSS_DEFAULT = (
-    '''
-    :checked,
-
-    /*
-    This pattern must be at the end.
-    Special logic is applied to the last selector.
-    */
-    html|form html|*:is(button, input)[type="submit"]
-    ''',
-    FLG_DEFAULT
-)
-# CSS pattern for `:indeterminate`
-CSS_INDETERMINATE = (
-    '''
-    html|input[type="checkbox"][indeterminate],
-    html|input[type="radio"]:is(:not([name]), [name=""]):not([checked]),
-    html|progress:not([value]),
-
-    /*
-    This pattern must be at the end.
-    Special logic is applied to the last selector.
-    */
-    html|input[type="radio"][name]:not([name='']):not([checked])
-    ''',
-    FLG_INDETERMINATE
-)
-# CSS pattern for `:disabled`
-CSS_DISABLED = (
-    '''
-    html|*:is(input:not([type=hidden]), button, select, textarea, fieldset, optgroup, option, fieldset)[disabled],
-    html|optgroup[disabled] > html|option,
-    html|fieldset[disabled] > html|*:is(input:not([type=hidden]), button, select, textarea, fieldset),
-    html|fieldset[disabled] >
-        html|*:not(legend:nth-of-type(1)) html|*:is(input:not([type=hidden]), button, select, textarea, fieldset)
-    ''',
-    0
-)
-# CSS pattern for `:enabled`
-CSS_ENABLED = (
-    '''
-    html|*:is(input:not([type=hidden]), button, select, textarea, fieldset, optgroup, option, fieldset):not(:disabled)
-    ''',
-    FLG_HTML
-)
-# CSS pattern for `:required`
-CSS_REQUIRED = ('html|*:is(input, textarea, select)[required]', 0)
-# CSS pattern for `:optional`
-CSS_OPTIONAL = ('html|*:is(input, textarea, select):not([required])', 0)
-# CSS pattern for `:placeholder-shown`
-CSS_PLACEHOLDER_SHOWN = (
-    '''
-    html|input:is(
-        :not([type]),
-        [type=""],
-        [type=text],
-        [type=search],
-        [type=url],
-        [type=tel],
-        [type=email],
-        [type=password],
-        [type=number]
-    )[placeholder]:not([placeholder='']):is(:not([value]), [value=""]),
-    html|textarea[placeholder]:not([placeholder=''])
-    ''',
-    FLG_PLACEHOLDER_SHOWN
-)
-# CSS pattern default for `:nth-child` "of S" feature
-CSS_NTH_OF_S_DEFAULT = None
-# CSS pattern for `:read-write` (CSS_DISABLED must be compiled first)
-CSS_READ_WRITE = (
-    '''
-    html|*:is(
-        textarea,
-        input:is(
-            :not([type]),
-            [type=""],
-            [type=text],
-            [type=search],
-            [type=url],
-            [type=tel],
-            [type=email],
-            [type=number],
-            [type=password],
-            [type=date],
-            [type=datetime-local],
-            [type=month],
-            [type=time],
-            [type=week]
-        )
-    ):not([readonly], :disabled),
-    html|*:is([contenteditable=""], [contenteditable="true" i])
-    ''',
-    0
-)
-# CSS pattern for `:read-only`
-CSS_READ_ONLY = ('html|*:not(:read-write)', 0)
-# CSS pattern for `:in-range`
-CSS_IN_RANGE = (
-    '''
-    html|input:is(
-        [type="date"],
-        [type="month"],
-        [type="week"],
-        [type="time"],
-        [type="datetime-local"],
-        [type="number"],
-        [type="range"]
-    ):is(
-        [min],
-        [max]
-    )
-    ''',
-    FLG_IN_RANGE
-)
-# CSS pattern for `:out-of-range`
-CSS_OUT_OF_RANGE = (
-    '''
-    html|input:is(
-        [type="date"],
-        [type="month"],
-        [type="week"],
-        [type="time"],
-        [type="datetime-local"],
-        [type="number"],
-        [type="range"]
-    ):is(
-        [min],
-        [max]
-    )
-    ''',
-    FLG_OUT_OF_RANGE
-)
-
-# CSS pattern for :open
-CSS_OPEN = ('html|*:is(details, dialog)[open]', 0)
-
-
-# CSS pattern for :muted
-CSS_MUTED = ('html|*:is(video, audio)[muted]', 0)

--- a/soupsieve/css_parser.py
+++ b/soupsieve/css_parser.py
@@ -431,8 +431,9 @@ class CSSParser:
     """Parse CSS selectors."""
 
     css_tokens = (
-        SelectorPattern("pseudo_close", PAT_PSEUDO_CLOSE),
-        SpecialPseudoPattern(
+        (SelectorPattern, "pseudo_close", PAT_PSEUDO_CLOSE),
+        (
+            SpecialPseudoPattern,
             (
                 (
                     "pseudo_contains",
@@ -446,16 +447,16 @@ class CSSParser:
                 ("pseudo_dir", (':dir',), PAT_PSEUDO_DIR, SelectorPattern)
             )
         ),
-        SelectorPattern("pseudo_class_custom", PAT_PSEUDO_CLASS_CUSTOM),
-        SelectorPattern("pseudo_class", PAT_PSEUDO_CLASS),
-        SelectorPattern("pseudo_element", PAT_PSEUDO_ELEMENT),
-        SelectorPattern("amp", PAT_AMP),
-        SelectorPattern("at_rule", PAT_AT_RULE),
-        SelectorPattern("id", PAT_ID),
-        SelectorPattern("class", PAT_CLASS),
-        SelectorPattern("tag", PAT_TAG),
-        SelectorPattern("attribute", PAT_ATTR),
-        SelectorPattern("combine", PAT_COMBINE)
+        (SelectorPattern, "pseudo_class_custom", PAT_PSEUDO_CLASS_CUSTOM),
+        (SelectorPattern, "pseudo_class", PAT_PSEUDO_CLASS),
+        (SelectorPattern, "pseudo_element", PAT_PSEUDO_ELEMENT),
+        (SelectorPattern, "amp", PAT_AMP),
+        (SelectorPattern, "at_rule", PAT_AT_RULE),
+        (SelectorPattern, "id", PAT_ID),
+        (SelectorPattern, "class", PAT_CLASS),
+        (SelectorPattern, "tag", PAT_TAG),
+        (SelectorPattern, "attribute", PAT_ATTR),
+        (SelectorPattern, "combine", PAT_COMBINE)
     )
 
     def __init__(
@@ -605,6 +606,26 @@ class CSSParser:
         if complex_pseudo and pseudo in PSEUDO_COMPLEX:
             has_selector = self.parse_pseudo_open(sel, pseudo, has_selector, iselector, m.end(0))
         elif not complex_pseudo and pseudo in PSEUDO_SIMPLE:
+            # Pseudos that expand to selectors
+            PSEUDO_SELECTORS = {
+                ':link': CSS_LINK,
+                ':any-link': CSS_LINK,
+                ':checked': CSS_CHECKED,
+                ':default': CSS_DEFAULT,
+                ':indeterminate': CSS_INDETERMINATE,
+                ':disabled': CSS_DISABLED,
+                ':enabled': CSS_ENABLED,
+                ':required': CSS_REQUIRED,
+                ':muted': CSS_MUTED,
+                ':open': CSS_OPEN,
+                ':optional': CSS_OPTIONAL,
+                ':read-only': CSS_READ_ONLY,
+                ':read-write': CSS_READ_WRITE,
+                ':in-range': CSS_IN_RANGE,
+                ':out-of-range': CSS_OUT_OF_RANGE,
+                ':placeholder-shown': CSS_PLACEHOLDER_SHOWN
+            }
+
             if pseudo == ':root':
                 sel.flags |= ct.SEL_ROOT
             elif pseudo == ':defined':
@@ -614,66 +635,15 @@ class CSSParser:
                 sel.flags |= ct.SEL_SCOPE
             elif pseudo == ':empty':
                 sel.flags |= ct.SEL_EMPTY
-            elif pseudo in (':link', ':any-link'):
-                self.count += CSS_LINK.count
+            elif pseudo in PSEUDO_SELECTORS:
+                if isinstance(PSEUDO_SELECTORS[pseudo], tuple):
+                    PSEUDO_SELECTORS[pseudo] = CSSParser(
+                        PSEUDO_SELECTORS[pseudo][0]
+                    ).process_selectors(flags=FLG_PSEUDO | FLG_HTML | PSEUDO_SELECTORS[pseudo][1])
+
+                self.count += PSEUDO_SELECTORS[pseudo].count
                 self.check_count()
-                sel.selectors.append(CSS_LINK)
-            elif pseudo == ':checked':
-                self.count += CSS_CHECKED.count
-                self.check_count()
-                sel.selectors.append(CSS_CHECKED)
-            elif pseudo == ':default':
-                self.count += CSS_DEFAULT.count
-                self.check_count()
-                sel.selectors.append(CSS_DEFAULT)
-            elif pseudo == ':indeterminate':
-                self.count += CSS_INDETERMINATE.count
-                self.check_count()
-                sel.selectors.append(CSS_INDETERMINATE)
-            elif pseudo == ":disabled":
-                self.count += CSS_DISABLED.count
-                self.check_count()
-                sel.selectors.append(CSS_DISABLED)
-            elif pseudo == ":enabled":
-                self.count += CSS_ENABLED.count
-                self.check_count()
-                sel.selectors.append(CSS_ENABLED)
-            elif pseudo == ":required":
-                self.count += CSS_REQUIRED.count
-                self.check_count()
-                sel.selectors.append(CSS_REQUIRED)
-            elif pseudo == ":muted":
-                self.count += CSS_MUTED.count
-                self.check_count()
-                sel.selectors.append(CSS_MUTED)
-            elif pseudo == ":open":
-                self.count += CSS_OPEN.count
-                self.check_count()
-                sel.selectors.append(CSS_OPEN)
-            elif pseudo == ":optional":
-                self.count += CSS_OPTIONAL.count
-                self.check_count()
-                sel.selectors.append(CSS_OPTIONAL)
-            elif pseudo == ":read-only":
-                self.count += CSS_READ_ONLY.count
-                self.check_count()
-                sel.selectors.append(CSS_READ_ONLY)
-            elif pseudo == ":read-write":
-                self.count += CSS_READ_WRITE.count
-                self.check_count()
-                sel.selectors.append(CSS_READ_WRITE)
-            elif pseudo == ":in-range":
-                self.count += CSS_IN_RANGE.count
-                self.check_count()
-                sel.selectors.append(CSS_IN_RANGE)
-            elif pseudo == ":out-of-range":
-                self.count += CSS_OUT_OF_RANGE.count
-                self.check_count()
-                sel.selectors.append(CSS_OUT_OF_RANGE)
-            elif pseudo == ":placeholder-shown":
-                self.count += CSS_PLACEHOLDER_SHOWN.count
-                self.check_count()
-                sel.selectors.append(CSS_PLACEHOLDER_SHOWN)
+                sel.selectors.append(PSEUDO_SELECTORS[pseudo])
             elif pseudo == ':first-child':
                 sel.nth.append(ct.SelectorNth(1, False, 0, False, False, ct.SelectorList()))
             elif pseudo == ':last-child':
@@ -772,6 +742,10 @@ class CSSParser:
                 nth_sel = self.parse_selectors(iselector, m.end(0), FLG_PSEUDO | FLG_OPEN)
             else:
                 # Use default `*|*` for `of S`.
+                global CSS_NTH_OF_S_DEFAULT
+                if not CSS_NTH_OF_S_DEFAULT:
+                   CSS_NTH_OF_S_DEFAULT = CSSParser('*|*').process_selectors(flags=FLG_PSEUDO)
+
                 nth_sel = CSS_NTH_OF_S_DEFAULT
                 self.count += nth_sel.count
                 self.check_count()
@@ -1168,6 +1142,8 @@ class CSSParser:
         while index <= end:
             m = None
             for v in self.css_tokens:
+                if not isinstance(v, SelectorPattern):
+                    v = v[0](*v[1:])
                 m = v.match(pattern, index, self.flags)
                 if m:
                     name = v.get_name()
@@ -1201,21 +1177,17 @@ class CSSParser:
         return self.parse_selectors(self.selector_iter(self.pattern), index, flags)
 
 
-# Precompile CSS selector lists for pseudo-classes (additional logic may be required beyond the pattern)
-# A few patterns are order dependent as they use patterns previous compiled.
-
 # CSS pattern for `:link` and `:any-link`
-CSS_LINK = CSSParser(
-    'html|*:is(a, area)[href]'
-).process_selectors(flags=FLG_PSEUDO | FLG_HTML)
+CSS_LINK = ('html|*:is(a, area)[href]', 0)
 # CSS pattern for `:checked`
-CSS_CHECKED = CSSParser(
+CSS_CHECKED = (
     '''
     html|*:is(input[type=checkbox], input[type=radio])[checked], html|option[selected]
-    '''
-).process_selectors(flags=FLG_PSEUDO | FLG_HTML)
+    ''',
+    0
+)
 # CSS pattern for `:default` (must compile CSS_CHECKED first)
-CSS_DEFAULT = CSSParser(
+CSS_DEFAULT = (
     '''
     :checked,
 
@@ -1224,10 +1196,11 @@ CSS_DEFAULT = CSSParser(
     Special logic is applied to the last selector.
     */
     html|form html|*:is(button, input)[type="submit"]
-    '''
-).process_selectors(flags=FLG_PSEUDO | FLG_HTML | FLG_DEFAULT)
+    ''',
+    FLG_DEFAULT
+)
 # CSS pattern for `:indeterminate`
-CSS_INDETERMINATE = CSSParser(
+CSS_INDETERMINATE = (
     '''
     html|input[type="checkbox"][indeterminate],
     html|input[type="radio"]:is(:not([name]), [name=""]):not([checked]),
@@ -1238,34 +1211,33 @@ CSS_INDETERMINATE = CSSParser(
     Special logic is applied to the last selector.
     */
     html|input[type="radio"][name]:not([name='']):not([checked])
-    '''
-).process_selectors(flags=FLG_PSEUDO | FLG_HTML | FLG_INDETERMINATE)
+    ''',
+    FLG_INDETERMINATE
+)
 # CSS pattern for `:disabled`
-CSS_DISABLED = CSSParser(
+CSS_DISABLED = (
     '''
     html|*:is(input:not([type=hidden]), button, select, textarea, fieldset, optgroup, option, fieldset)[disabled],
     html|optgroup[disabled] > html|option,
     html|fieldset[disabled] > html|*:is(input:not([type=hidden]), button, select, textarea, fieldset),
     html|fieldset[disabled] >
         html|*:not(legend:nth-of-type(1)) html|*:is(input:not([type=hidden]), button, select, textarea, fieldset)
-    '''
-).process_selectors(flags=FLG_PSEUDO | FLG_HTML)
+    ''',
+    0
+)
 # CSS pattern for `:enabled`
-CSS_ENABLED = CSSParser(
+CSS_ENABLED = (
     '''
     html|*:is(input:not([type=hidden]), button, select, textarea, fieldset, optgroup, option, fieldset):not(:disabled)
-    '''
-).process_selectors(flags=FLG_PSEUDO | FLG_HTML)
+    ''',
+    FLG_HTML
+)
 # CSS pattern for `:required`
-CSS_REQUIRED = CSSParser(
-    'html|*:is(input, textarea, select)[required]'
-).process_selectors(flags=FLG_PSEUDO | FLG_HTML)
+CSS_REQUIRED = ('html|*:is(input, textarea, select)[required]', 0)
 # CSS pattern for `:optional`
-CSS_OPTIONAL = CSSParser(
-    'html|*:is(input, textarea, select):not([required])'
-).process_selectors(flags=FLG_PSEUDO | FLG_HTML)
+CSS_OPTIONAL = ('html|*:is(input, textarea, select):not([required])', 0)
 # CSS pattern for `:placeholder-shown`
-CSS_PLACEHOLDER_SHOWN = CSSParser(
+CSS_PLACEHOLDER_SHOWN = (
     '''
     html|input:is(
         :not([type]),
@@ -1279,14 +1251,13 @@ CSS_PLACEHOLDER_SHOWN = CSSParser(
         [type=number]
     )[placeholder]:not([placeholder='']):is(:not([value]), [value=""]),
     html|textarea[placeholder]:not([placeholder=''])
-    '''
-).process_selectors(flags=FLG_PSEUDO | FLG_HTML | FLG_PLACEHOLDER_SHOWN)
+    ''',
+    FLG_PLACEHOLDER_SHOWN
+)
 # CSS pattern default for `:nth-child` "of S" feature
-CSS_NTH_OF_S_DEFAULT = CSSParser(
-    '*|*'
-).process_selectors(flags=FLG_PSEUDO)
+CSS_NTH_OF_S_DEFAULT = None
 # CSS pattern for `:read-write` (CSS_DISABLED must be compiled first)
-CSS_READ_WRITE = CSSParser(
+CSS_READ_WRITE = (
     '''
     html|*:is(
         textarea,
@@ -1308,16 +1279,13 @@ CSS_READ_WRITE = CSSParser(
         )
     ):not([readonly], :disabled),
     html|*:is([contenteditable=""], [contenteditable="true" i])
-    '''
-).process_selectors(flags=FLG_PSEUDO | FLG_HTML)
+    ''',
+    0
+)
 # CSS pattern for `:read-only`
-CSS_READ_ONLY = CSSParser(
-    '''
-    html|*:not(:read-write)
-    '''
-).process_selectors(flags=FLG_PSEUDO | FLG_HTML)
+CSS_READ_ONLY = ('html|*:not(:read-write)', 0)
 # CSS pattern for `:in-range`
-CSS_IN_RANGE = CSSParser(
+CSS_IN_RANGE = (
     '''
     html|input:is(
         [type="date"],
@@ -1331,10 +1299,11 @@ CSS_IN_RANGE = CSSParser(
         [min],
         [max]
     )
-    '''
-).process_selectors(flags=FLG_PSEUDO | FLG_IN_RANGE | FLG_HTML)
+    ''',
+    FLG_IN_RANGE
+)
 # CSS pattern for `:out-of-range`
-CSS_OUT_OF_RANGE = CSSParser(
+CSS_OUT_OF_RANGE = (
     '''
     html|input:is(
         [type="date"],
@@ -1348,20 +1317,13 @@ CSS_OUT_OF_RANGE = CSSParser(
         [min],
         [max]
     )
-    '''
-).process_selectors(flags=FLG_PSEUDO | FLG_OUT_OF_RANGE | FLG_HTML)
+    ''',
+    FLG_OUT_OF_RANGE
+)
 
 # CSS pattern for :open
-CSS_OPEN = CSSParser(
-    '''
-    html|*:is(details, dialog)[open]
-    '''
-).process_selectors(flags=FLG_PSEUDO | FLG_HTML)
+CSS_OPEN = ('html|*:is(details, dialog)[open]', 0)
 
 
 # CSS pattern for :muted
-CSS_MUTED = CSSParser(
-    '''
-    html|*:is(video, audio)[muted]
-    '''
-).process_selectors(flags=FLG_PSEUDO | FLG_HTML)
+CSS_MUTED = ('html|*:is(video, audio)[muted]', 0)

--- a/soupsieve/css_parser.py
+++ b/soupsieve/css_parser.py
@@ -432,21 +432,22 @@ class _Selector:
 
 
 @dataclass
-class PseudoSelector:
+class CSSPattern:
+    """A CSS pattern that hasn't been processed by CSSParser yet."""
     selector: str
     flags: int
 
 # CSS pattern for `:link` and `:any-link`
-CSS_LINK = PseudoSelector('html|*:is(a, area)[href]', 0)
+CSS_LINK = CSSPattern('html|*:is(a, area)[href]', 0)
 # CSS pattern for `:checked`
-CSS_CHECKED = PseudoSelector(
+CSS_CHECKED = CSSPattern(
     '''
     html|*:is(input[type=checkbox], input[type=radio])[checked], html|option[selected]
     ''',
     0
 )
 # CSS pattern for `:default` (must compile CSS_CHECKED first)
-CSS_DEFAULT = PseudoSelector(
+CSS_DEFAULT = CSSPattern(
     '''
     :checked,
 
@@ -459,7 +460,7 @@ CSS_DEFAULT = PseudoSelector(
     FLG_DEFAULT
 )
 # CSS pattern for `:indeterminate`
-CSS_INDETERMINATE = PseudoSelector(
+CSS_INDETERMINATE = CSSPattern(
     '''
     html|input[type="checkbox"][indeterminate],
     html|input[type="radio"]:is(:not([name]), [name=""]):not([checked]),
@@ -474,7 +475,7 @@ CSS_INDETERMINATE = PseudoSelector(
     FLG_INDETERMINATE
 )
 # CSS pattern for `:disabled`
-CSS_DISABLED = PseudoSelector(
+CSS_DISABLED = CSSPattern(
     '''
     html|*:is(input:not([type=hidden]), button, select, textarea, fieldset, optgroup, option, fieldset)[disabled],
     html|optgroup[disabled] > html|option,
@@ -485,18 +486,18 @@ CSS_DISABLED = PseudoSelector(
     0
 )
 # CSS pattern for `:enabled`
-CSS_ENABLED = PseudoSelector(
+CSS_ENABLED = CSSPattern(
     '''
     html|*:is(input:not([type=hidden]), button, select, textarea, fieldset, optgroup, option, fieldset):not(:disabled)
     ''',
     FLG_HTML
 )
 # CSS pattern for `:required`
-CSS_REQUIRED = PseudoSelector('html|*:is(input, textarea, select)[required]', 0)
+CSS_REQUIRED = CSSPattern('html|*:is(input, textarea, select)[required]', 0)
 # CSS pattern for `:optional`
-CSS_OPTIONAL = PseudoSelector('html|*:is(input, textarea, select):not([required])', 0)
+CSS_OPTIONAL = CSSPattern('html|*:is(input, textarea, select):not([required])', 0)
 # CSS pattern for `:placeholder-shown`
-CSS_PLACEHOLDER_SHOWN = PseudoSelector(
+CSS_PLACEHOLDER_SHOWN = CSSPattern(
     '''
     html|input:is(
         :not([type]),
@@ -514,7 +515,7 @@ CSS_PLACEHOLDER_SHOWN = PseudoSelector(
     FLG_PLACEHOLDER_SHOWN
 )
 # CSS pattern for `:read-write` (CSS_DISABLED must be compiled first)
-CSS_READ_WRITE = PseudoSelector(
+CSS_READ_WRITE = CSSPattern(
     '''
     html|*:is(
         textarea,
@@ -540,9 +541,9 @@ CSS_READ_WRITE = PseudoSelector(
     0
 )
 # CSS pattern for `:read-only`
-CSS_READ_ONLY = PseudoSelector('html|*:not(:read-write)', 0)
+CSS_READ_ONLY = CSSPattern('html|*:not(:read-write)', 0)
 # CSS pattern for `:in-range`
-CSS_IN_RANGE = PseudoSelector(
+CSS_IN_RANGE = CSSPattern(
     '''
     html|input:is(
         [type="date"],
@@ -560,7 +561,7 @@ CSS_IN_RANGE = PseudoSelector(
     FLG_IN_RANGE
 )
 # CSS pattern for `:out-of-range`
-CSS_OUT_OF_RANGE = PseudoSelector(
+CSS_OUT_OF_RANGE = CSSPattern(
     '''
     html|input:is(
         [type="date"],
@@ -579,11 +580,11 @@ CSS_OUT_OF_RANGE = PseudoSelector(
 )
 
 # CSS pattern for :open
-CSS_OPEN = PseudoSelector('html|*:is(details, dialog)[open]', 0)
+CSS_OPEN = CSSPattern('html|*:is(details, dialog)[open]', 0)
 
 
 # CSS pattern for :muted
-CSS_MUTED = PseudoSelector('html|*:is(video, audio)[muted]', 0)
+CSS_MUTED = CSSPattern('html|*:is(video, audio)[muted]', 0)
 
 
 class CSSParser:
@@ -618,7 +619,7 @@ class CSSParser:
     )
 
     # Pseudos that expand to selectors
-    pseudo_selectors: dict[str, PseudoSelector | ct.SelectorList] = {
+    pseudo_selectors: dict[str, CSSPattern | ct.SelectorList] = {
         ':link': CSS_LINK,
         ':any-link': CSS_LINK,
         ':checked': CSS_CHECKED,
@@ -798,7 +799,7 @@ class CSSParser:
                 sel.flags |= ct.SEL_EMPTY
             elif pseudo in self.pseudo_selectors:
                 pseudo_selector = self.pseudo_selectors[pseudo]
-                if isinstance(pseudo_selector, PseudoSelector):
+                if isinstance(pseudo_selector, CSSPattern):
                     self.pseudo_selectors[pseudo] = pseudo_selector = CSSParser(
                         pseudo_selector.selector
                     ).process_selectors(

--- a/soupsieve/css_parser.py
+++ b/soupsieve/css_parser.py
@@ -179,6 +179,7 @@ RE_WS = re.compile(WS)
 RE_WS_BEGIN = re.compile(fr'^{WSC}*')
 RE_WS_END = re.compile(fr'{WSC}*$')
 RE_CUSTOM = re.compile(fr'^{PAT_PSEUDO_CLASS_CUSTOM}$', re.X)
+RE_PSEUDO_CLASS_SPECIAL = re.compile(PAT_PSEUDO_CLASS_SPECIAL, re.I | re.X | re.U)
 
 # Constants
 # List split token
@@ -338,7 +339,6 @@ class SpecialPseudoPattern(SelectorPattern):
                 self.patterns[pseudo] = pattern
 
         self.matched_name = None  # type: SelectorPattern | None
-        self.re_pseudo_name = re.compile(PAT_PSEUDO_CLASS_SPECIAL, re.I | re.X | re.U)
 
     def get_name(self) -> str:
         """Get name."""
@@ -349,7 +349,7 @@ class SpecialPseudoPattern(SelectorPattern):
         """Match the selector."""
 
         pseudo = None
-        m = self.re_pseudo_name.match(selector, index)
+        m = RE_PSEUDO_CLASS_SPECIAL.match(selector, index)
         if m:
             name = util.lower(css_unescape(m.group('name')))
             pattern = self.patterns.get(name)
@@ -630,6 +630,9 @@ class CSSParser:
         ':placeholder-shown': CSS_PLACEHOLDER_SHOWN
     }
 
+    # CSS pattern default for `:nth-child` "of S" feature
+    css_nth_of_s_default = None
+
     def __init__(
         self,
         selector: str,
@@ -895,7 +898,7 @@ class CSSParser:
                 nth_sel = self.parse_selectors(iselector, m.end(0), FLG_PSEUDO | FLG_OPEN)
             else:
                 # Use default `*|*` for `of S`.
-                if not hasattr(self, 'css_nth_of_s_default'):
+                if not self.css_nth_of_s_default:
                    self.css_nth_of_s_default = CSSParser('*|*').process_selectors(flags=FLG_PSEUDO)
 
                 nth_sel = self.css_nth_of_s_default

--- a/soupsieve/css_parser.py
+++ b/soupsieve/css_parser.py
@@ -310,7 +310,8 @@ class SelectorPattern:
         """Initialize."""
 
         self.name = name
-        self.re_pattern = pattern
+        self.pattern = pattern
+        self.re_pattern: re.Pattern[str] | None = None
 
     def get_name(self) -> str:
         """Get name."""
@@ -319,8 +320,8 @@ class SelectorPattern:
 
     def match(self, selector: str, index: int, flags: int) -> Match[str] | None:
         """Match the selector."""
-        if isinstance(self.re_pattern, str):
-            self.re_pattern = re.compile(self.re_pattern, re.I | re.X | re.U)
+        if not self.re_pattern:
+            self.re_pattern = re.compile(self.pattern, re.I | re.X | re.U)
 
         return self.re_pattern.match(selector, index)
 
@@ -611,7 +612,7 @@ class CSSParser:
     )
 
     # Pseudos that expand to selectors
-    pseudo_selectors = {
+    pseudo_selectors: dict[str, tuple[str, int] | ct.SelectorList] = {
         ':link': CSS_LINK,
         ':any-link': CSS_LINK,
         ':checked': CSS_CHECKED,
@@ -791,15 +792,19 @@ class CSSParser:
                 sel.flags |= ct.SEL_EMPTY
             elif pseudo in self.pseudo_selectors:
                 if isinstance(self.pseudo_selectors[pseudo], tuple):
-                    self.pseudo_selectors[pseudo] = CSSParser(
-                        self.pseudo_selectors[pseudo][0]
-                    ).process_selectors(
-                        flags=FLG_PSEUDO | FLG_HTML | self.pseudo_selectors[pseudo][1]
+                    selector = self.pseudo_selectors[pseudo][0]
+                    flags = self.pseudo_selectors[pseudo][1]
+                    assert isinstance(selector, str) and isinstance(flags, int)
+                    self.pseudo_selectors[pseudo] = CSSParser(selector).process_selectors(
+                        flags=FLG_PSEUDO | FLG_HTML | flags
                     )
 
-                self.count += self.pseudo_selectors[pseudo].count
+                pseudo_selector = self.pseudo_selectors[pseudo]
+                assert isinstance(pseudo_selector, ct.SelectorList)
+
+                self.count += pseudo_selector.count
                 self.check_count()
-                sel.selectors.append(self.pseudo_selectors[pseudo])
+                sel.selectors.append(pseudo_selector)
             elif pseudo == ':first-child':
                 sel.nth.append(ct.SelectorNth(1, False, 0, False, False, ct.SelectorList()))
             elif pseudo == ':last-child':

--- a/soupsieve/css_parser.py
+++ b/soupsieve/css_parser.py
@@ -433,7 +433,8 @@ class _Selector:
 
 @dataclass
 class CSSPattern:
-    """A CSS pattern that hasn't been processed by CSSParser yet."""
+    """A CSS pattern that hasn't been processed by `CSSParser` yet."""
+
     selector: str
     flags: int
 


### PR DESCRIPTION
Details in #295.

I've removed a lot of the equivalent elif blocks in `parse_pseudo_class` in favor of a dict, to make it more concise. I can change it back if you prefer.

Importing css_parser now takes ~5ms, rather than ~26ms.