### PR TITLE
Fix :nth-child/:nth-of-type matching for An+B index boundaries

### DIFF
--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -7,6 +7,7 @@ icon: lucide/scroll-text
 
 -   **NEW**: Drop Python 3.9 support.
 -   **NEW**: Lazy compile selector patterns to improve initial import speed.
+-   **FIX**: Correct `:nth-child`/`:nth-of-type` (and `-last-` variants) for `An+B` values whose sequence steps onto index 0 or onto the last child (e.g. `:nth-child(2n-2)`, `:nth-child(n-1)`, `:nth-child(n+5)`), which previously matched the wrong elements or nothing at all (@gaoflow).
 
 ## 2.8.4
 

--- a/soupsieve/css_match.py
+++ b/soupsieve/css_match.py
@@ -995,44 +995,18 @@ class CSSMatch(_DocumentNav):
 
             # We can only adjust bounds within a variable index
             if var:
-                # Abort if our nth index is out of bounds and only getting further out of bounds as we increment.
-                # Otherwise, increment to try to get in bounds.
-                adjust = None
-                while idx < 1 or idx > last_index:
-                    if idx < 0:
-                        diff_low = 0 - idx
-                        if adjust is not None and adjust == 1:
-                            break
-                        adjust = -1
-                        count += count_incr
-                        idx = last_idx = a * count + b if var else a
-                        diff = 0 - idx
-                        if diff >= diff_low:
-                            break
-                    else:
-                        diff_high = idx - last_index
-                        if adjust is not None and adjust == -1:
-                            break
-                        adjust = 1
-                        count += count_incr
-                        idx = last_idx = a * count + b if var else a
-                        diff = idx - last_index
-                        if diff >= diff_high:
-                            break
-                        diff_high = diff
-
-                # If a < 0, our count is working backwards, so floor the index by increasing the count.
-                # Find the count that yields the lowest, in bound value and use that.
-                # Lastly reverse count increment so that we'll increase our index.
-                lowest = count
-                if a < 0:
-                    while idx >= 1:
-                        lowest = count
-                        count += count_incr
-                        idx = last_idx = a * count + b if var else a
+                # Find the count `n` that yields the smallest in-bounds index
+                # (>= 1), then set the increment direction so that the index
+                # ascends from there as the evaluation loop below walks children.
+                if a > 0:
+                    # Ascending sequence: smallest n with a * n + b >= 1.
+                    count = 0 if b >= 1 else -(-(1 - b) // a)
+                elif a < 0:
+                    # Descending sequence: largest n with a * n + b >= 1, then
+                    # walk n back down so the index increases.
+                    count = (b - 1) // -a if b >= 1 else 0
                     count_incr = -1
-                count = lowest
-                idx = last_idx = a * count + b if var else a
+                idx = last_idx = a * count + b
 
             # Evaluate elements while our calculated nth index is still in range
             while 1 <= idx <= last_index + 1:

--- a/tests/test_level3/test_nth_child.py
+++ b/tests/test_level3/test_nth_child.py
@@ -244,3 +244,30 @@ class TestNthChild(util.TestCase):
         """Test that pseudo class fails with bad parameters (basically it doesn't match)."""
 
         self.assert_raises(':nth-child(a)', SelectorSyntaxError)
+
+    def test_nth_child_an_plus_b_boundaries(self):
+        """Test `An+B` forms whose sequence steps onto index 0 or the last child."""
+
+        markup = """
+        <body>
+        <i id="0"></i>
+        <i id="1"></i>
+        <i id="2"></i>
+        <i id="3"></i>
+        <i id="4"></i>
+        </body>
+        """
+
+        # `B < 1` sequences whose first valid index is > 1 or is all indices
+        self.assert_selector(markup, "i:nth-child(2n-2)", ['1', '3'], flags=util.HTML)
+        self.assert_selector(
+            markup, "i:nth-child(n-1)", ['0', '1', '2', '3', '4'], flags=util.HTML
+        )
+        # `B` equal to the child count (index lands on the last child)
+        self.assert_selector(markup, "i:nth-child(n+5)", ['4'], flags=util.HTML)
+        self.assert_selector(markup, "i:nth-child(2n+5)", ['4'], flags=util.HTML)
+        # same boundaries, counted from the end
+        self.assert_selector(
+            markup, "i:nth-last-child(2n-2)", ['1', '3'], flags=util.HTML
+        )
+        self.assert_selector(markup, "i:nth-last-child(n+5)", ['0'], flags=util.HTML)


### PR DESCRIPTION
`:nth-child(An+B)` / `:nth-of-type` (and their `-last-` variants) silently match the wrong elements — usually nothing — for several valid `An+B` micro-syntaxes, disagreeing with the CSS spec and lxml/every browser:

```pycon
>>> import soupsieve as sv
>>> from bs4 import BeautifulSoup
>>> div = BeautifulSoup("<div>" + "<i></i>" * 3 + "</div>", "html.parser").div
>>> len(sv.select(":nth-child(2n-2)", div))   # should match the 2nd child
0
>>> len(sv.select(":nth-child(n-1)", div))    # should match all children
0
>>> div5 = BeautifulSoup("<div>" + "<i></i>" * 5 + "</div>", "html.parser").div
>>> len(sv.select(":nth-child(n+5)", div5))   # should match the 5th child
0
```

Per the spec, `:nth-child(an+b)` matches an element whose 1-based index equals `a·n + b` for some integer `n ≥ 0`, so `n-1` (indices 1, 2, 3, …) should match every child and `n+5` should match the 5th. Existing tests pass only because their markup is large enough that these sequences never land exactly on index 0 and `b` stays within the child count.

### Cause

`CSSMatch.match_nth` picks the starting `count` (`n`) with a hand-rolled loop that walks the index toward the valid range using signed "diff" heuristics. It has three boundary faults: it treats index `0` as "not too low" (so a step landing on `0` aborts down the wrong branch), it bounds the search to `<= last_index` while the evaluation loop accepts `<= last_index + 1` (so the case where the only match is the last child bails out early), and the `a < 0` branch stops early for some inputs.

### Fix

Replace the heuristic with the direct closed form for the first in-range `n`:

- `a > 0`: the smallest `n` with `a·n + b >= 1` — `0` when `b >= 1`, otherwise `ceil((1 - b) / a)`.
- `a < 0`: the largest such `n`, then walk `n` downward so the index ascends as the evaluation loop (unchanged) walks the children.

The result is a net reduction in code and matches the spec.

### Verification

- Full test suite passes (394 passed).
- New `test_nth_child_an_plus_b_boundaries` covers the child- and last-child boundary forms, with expected results cross-checked against lxml.
- Differential fuzz vs `lxml`/`cssselect` over 12,000 random cases (`:nth-child` / `nth-of-type` / `nth-last-*`, `a, b` over `[-4..4] × [-6..6]`, 1–10 children, mixed tag types, with and without inter-tag whitespace): **0 disagreements** after the fix (738 before).
- `ruff check .` and `mypy` are clean.
