### PR TITLE
Match nothing for empty-value substring attribute selectors

### DIFF
--- a/docs/src/markdown/about/changelog.md
+++ b/docs/src/markdown/about/changelog.md
@@ -12,6 +12,9 @@ icon: lucide/scroll-text
     matched the wrong elements or nothing at all (@gaoflow).
 -   **FIX**: More efficient CSS ID matching (@kaimandalic).
 -   **FIX**: Fix inefficient trimming of comments and white space (@kaimandalic).
+-   **FIX**: Correct `[attr^=""]`, `[attr$=""]`, and `[attr*=""]` to match nothing when the value is empty, per CSS
+    Selectors Level 4 substring matching, which previously matched any element merely having the attribute
+    (@chuenchen309).
 
 ## 2.8.4
 

--- a/soupsieve/css_parser.py
+++ b/soupsieve/css_parser.py
@@ -725,13 +725,19 @@ class CSSParser:
             pattern = None
         elif op.startswith('^'):
             # Value start with
-            pattern = re.compile(r'^%s.*' % re.escape(value), flags)
+            # `^=` should match nothing if the value is empty, so use `[^\s\S]` which cannot be matched.
+            value = r'[^\s\S]' if not value else re.escape(value)
+            pattern = re.compile(r'^%s.*' % value, flags)
         elif op.startswith('$'):
             # Value ends with
-            pattern = re.compile(r'.*?%s$' % re.escape(value), flags)
+            # `$=` should match nothing if the value is empty, so use `[^\s\S]` which cannot be matched.
+            value = r'[^\s\S]' if not value else re.escape(value)
+            pattern = re.compile(r'.*?%s$' % value, flags)
         elif op.startswith('*'):
             # Value contains
-            pattern = re.compile(r'.*?%s.*' % re.escape(value), flags)
+            # `*=` should match nothing if the value is empty, so use `[^\s\S]` which cannot be matched.
+            value = r'[^\s\S]' if not value else re.escape(value)
+            pattern = re.compile(r'.*?%s.*' % value, flags)
         elif op.startswith('~'):
             # Value contains word within space separated list
             # `~=` should match nothing if it is empty or contains whitespace,

--- a/tests/test_level3/test_attribute.py
+++ b/tests/test_level3/test_attribute.py
@@ -61,6 +61,39 @@ class TestAttribute(util.TestCase):
             flags=util.HTML
         )
 
+    def test_attribute_begins_cannot_have_empty(self):
+        """Test attribute `^=` will match nothing when value is empty."""
+
+        # An empty value cannot match anything per the spec.
+        self.assert_selector(
+            self.MARKUP,
+            '[class^=""]',
+            [],
+            flags=util.HTML
+        )
+
+    def test_attribute_end_cannot_have_empty(self):
+        """Test attribute `$=` will match nothing when value is empty."""
+
+        # An empty value cannot match anything per the spec.
+        self.assert_selector(
+            self.MARKUP,
+            '[class$=""]',
+            [],
+            flags=util.HTML
+        )
+
+    def test_attribute_contains_cannot_have_empty(self):
+        """Test attribute `*=` will match nothing when value is empty."""
+
+        # An empty value cannot match anything per the spec.
+        self.assert_selector(
+            self.MARKUP,
+            '[class*=""]',
+            [],
+            flags=util.HTML
+        )
+
     def test_attribute_contains_with_newlines(self):
         """Test attribute `*=` will match with new lines."""
 


### PR DESCRIPTION
## Summary

The substring attribute selectors `[attr^=""]`, `[attr$=""]`, and `[attr*=""]` currently match **every** element that merely *has* the attribute, when they should match **nothing** if the value is empty.

Per [CSS Selectors Level 4 §6.2 (Substring matching attribute selectors)](https://www.w3.org/TR/selectors-4/#attribute-substrings):

> `[att^=val]` — Represents an element with the `att` attribute whose value begins with the prefix "val". **If "val" is the empty string then the selector does not represent anything.**
> `[att$=val]` — … **If "val" is the empty string then the selector does not represent anything.**
> `[att*=val]` — … **If "val" is the empty string then the selector does not represent anything.**

Browsers agree: `document.querySelectorAll('[href^=""]')` returns an empty `NodeList`.

## Root cause

In `parse_attribute_selector`, an empty value compiles to `^.*` / `.*?$` / `.*?.*`, which matches any value. The sibling `~=` operator already special-cases the empty value to the never-match sentinel `[^\s\S]` — this PR extends the identical handling to the three substring operators (self-consistency).

## Reproduction

```python
import soupsieve as sv
from bs4 import BeautifulSoup
soup = BeautifulSoup('<a href="foo">1</a><a href="">2</a>', 'html.parser')
```

| selector | before (actual) | after / spec-correct |
|---|---|---|
| `[href^=""]` | `['1', '2']` | `[]` |
| `[href$=""]` | `['1', '2']` | `[]` |
| `[href*=""]` | `['1', '2']` | `[]` |
| `[href~=""]` | `[]` (already correct) | `[]` |

Non-empty values (`[href^=f]` → `['1']`) and the case-insensitive `i` flag are unaffected.

## Verification

- 3 new tests in `tests/test_level3/test_attribute.py` (styled on the existing `~=` empty-value test) **fail on the unfixed tree, pass after the fix**.
- Full suite: **397 passed, 1 skipped**, no regressions.
- Changelog entry added under 2.9.

Related history: closed issue #30 introduced the `~=` empty-value handling — confirming this exact spec point is treated as a real bug; the substring operators were simply missed.

---

*This PR was authored by an AI coding agent (Claude Code) running on this account: the AI found the bug, ran the repro, wrote the tests, and wrote this description. The human account holder reviews every change and is accountable for it. The verification above is real and re-runnable from the diff. If this isn't the kind of contribution you want, say so and I'll close it.*
